### PR TITLE
feat: add betting logic

### DIFF
--- a/abi/conditionalTokens.json
+++ b/abi/conditionalTokens.json
@@ -1,0 +1,331 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "owner", "type": "address" },
+      { "name": "id", "type": "uint256" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "collateralToken", "type": "address" },
+      { "name": "parentCollectionId", "type": "bytes32" },
+      { "name": "conditionId", "type": "bytes32" },
+      { "name": "indexSets", "type": "uint256[]" }
+    ],
+    "name": "redeemPositions",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "interfaceId", "type": "bytes4" }],
+    "name": "supportsInterface",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "", "type": "bytes32" },
+      { "name": "", "type": "uint256" }
+    ],
+    "name": "payoutNumerators",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "ids", "type": "uint256[]" },
+      { "name": "values", "type": "uint256[]" },
+      { "name": "data", "type": "bytes" }
+    ],
+    "name": "safeBatchTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "collateralToken", "type": "address" },
+      { "name": "collectionId", "type": "bytes32" }
+    ],
+    "name": "getPositionId",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "owners", "type": "address[]" },
+      { "name": "ids", "type": "uint256[]" }
+    ],
+    "name": "balanceOfBatch",
+    "outputs": [{ "name": "", "type": "uint256[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "collateralToken", "type": "address" },
+      { "name": "parentCollectionId", "type": "bytes32" },
+      { "name": "conditionId", "type": "bytes32" },
+      { "name": "partition", "type": "uint256[]" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "name": "splitPosition",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "oracle", "type": "address" },
+      { "name": "questionId", "type": "bytes32" },
+      { "name": "outcomeSlotCount", "type": "uint256" }
+    ],
+    "name": "getConditionId",
+    "outputs": [{ "name": "", "type": "bytes32" }],
+    "payable": false,
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "parentCollectionId", "type": "bytes32" },
+      { "name": "conditionId", "type": "bytes32" },
+      { "name": "indexSet", "type": "uint256" }
+    ],
+    "name": "getCollectionId",
+    "outputs": [{ "name": "", "type": "bytes32" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "collateralToken", "type": "address" },
+      { "name": "parentCollectionId", "type": "bytes32" },
+      { "name": "conditionId", "type": "bytes32" },
+      { "name": "partition", "type": "uint256[]" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "name": "mergePositions",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "operator", "type": "address" },
+      { "name": "approved", "type": "bool" }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "questionId", "type": "bytes32" },
+      { "name": "payouts", "type": "uint256[]" }
+    ],
+    "name": "reportPayouts",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "conditionId", "type": "bytes32" }],
+    "name": "getOutcomeSlotCount",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "oracle", "type": "address" },
+      { "name": "questionId", "type": "bytes32" },
+      { "name": "outcomeSlotCount", "type": "uint256" }
+    ],
+    "name": "prepareCondition",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "", "type": "bytes32" }],
+    "name": "payoutDenominator",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "owner", "type": "address" },
+      { "name": "operator", "type": "address" }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "id", "type": "uint256" },
+      { "name": "value", "type": "uint256" },
+      { "name": "data", "type": "bytes" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "conditionId", "type": "bytes32" },
+      { "indexed": true, "name": "oracle", "type": "address" },
+      { "indexed": true, "name": "questionId", "type": "bytes32" },
+      { "indexed": false, "name": "outcomeSlotCount", "type": "uint256" }
+    ],
+    "name": "ConditionPreparation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "conditionId", "type": "bytes32" },
+      { "indexed": true, "name": "oracle", "type": "address" },
+      { "indexed": true, "name": "questionId", "type": "bytes32" },
+      { "indexed": false, "name": "outcomeSlotCount", "type": "uint256" },
+      { "indexed": false, "name": "payoutNumerators", "type": "uint256[]" }
+    ],
+    "name": "ConditionResolution",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "stakeholder", "type": "address" },
+      { "indexed": false, "name": "collateralToken", "type": "address" },
+      { "indexed": true, "name": "parentCollectionId", "type": "bytes32" },
+      { "indexed": true, "name": "conditionId", "type": "bytes32" },
+      { "indexed": false, "name": "partition", "type": "uint256[]" },
+      { "indexed": false, "name": "amount", "type": "uint256" }
+    ],
+    "name": "PositionSplit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "stakeholder", "type": "address" },
+      { "indexed": false, "name": "collateralToken", "type": "address" },
+      { "indexed": true, "name": "parentCollectionId", "type": "bytes32" },
+      { "indexed": true, "name": "conditionId", "type": "bytes32" },
+      { "indexed": false, "name": "partition", "type": "uint256[]" },
+      { "indexed": false, "name": "amount", "type": "uint256" }
+    ],
+    "name": "PositionsMerge",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "redeemer", "type": "address" },
+      { "indexed": true, "name": "collateralToken", "type": "address" },
+      { "indexed": true, "name": "parentCollectionId", "type": "bytes32" },
+      { "indexed": false, "name": "conditionId", "type": "bytes32" },
+      { "indexed": false, "name": "indexSets", "type": "uint256[]" },
+      { "indexed": false, "name": "payout", "type": "uint256" }
+    ],
+    "name": "PayoutRedemption",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "operator", "type": "address" },
+      { "indexed": true, "name": "from", "type": "address" },
+      { "indexed": true, "name": "to", "type": "address" },
+      { "indexed": false, "name": "id", "type": "uint256" },
+      { "indexed": false, "name": "value", "type": "uint256" }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "operator", "type": "address" },
+      { "indexed": true, "name": "from", "type": "address" },
+      { "indexed": true, "name": "to", "type": "address" },
+      { "indexed": false, "name": "ids", "type": "uint256[]" },
+      { "indexed": false, "name": "values", "type": "uint256[]" }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "name": "owner", "type": "address" },
+      { "indexed": true, "name": "operator", "type": "address" },
+      { "indexed": false, "name": "approved", "type": "bool" }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "name": "value", "type": "string" },
+      { "indexed": true, "name": "id", "type": "uint256" }
+    ],
+    "name": "URI",
+    "type": "event"
+  }
+]

--- a/abi/market.json
+++ b/abi/market.json
@@ -1,0 +1,653 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawFees",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "feesWithdrawableBy",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "investmentAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "outcomeIndex",
+        "type": "uint256"
+      },
+      {
+        "name": "minOutcomeTokensToBuy",
+        "type": "uint256"
+      }
+    ],
+    "name": "buy",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "returnAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "outcomeIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "calcSellAmount",
+    "outputs": [
+      {
+        "name": "outcomeTokenSellAmount",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "conditionalTokens",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "collectedFees",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "collateralToken",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "name": "values",
+        "type": "uint256[]"
+      },
+      {
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "returnAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "outcomeIndex",
+        "type": "uint256"
+      },
+      {
+        "name": "maxOutcomeTokensToSell",
+        "type": "uint256"
+      }
+    ],
+    "name": "sell",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "addedFunds",
+        "type": "uint256"
+      },
+      {
+        "name": "distributionHint",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "addFunding",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "conditionIds",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "fee",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "sharesToBurn",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeFunding",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "investmentAmount",
+        "type": "uint256"
+      },
+      {
+        "name": "outcomeIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "calcBuyAmount",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "funder",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amountsAdded",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "name": "sharesMinted",
+        "type": "uint256"
+      }
+    ],
+    "name": "FPMMFundingAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "funder",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amountsRemoved",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "name": "collateralRemovedFromFeePool",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "sharesBurnt",
+        "type": "uint256"
+      }
+    ],
+    "name": "FPMMFundingRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "buyer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "investmentAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "feeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "outcomeIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "outcomeTokensBought",
+        "type": "uint256"
+      }
+    ],
+    "name": "FPMMBuy",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "returnAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "feeAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "name": "outcomeIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "outcomeTokensSold",
+        "type": "uint256"
+      }
+    ],
+    "name": "FPMMSell",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  }
+]

--- a/app/components/Swapbox.tsx
+++ b/app/components/Swapbox.tsx
@@ -2,11 +2,117 @@
 
 import { Button, IconButton } from "swapr-ui";
 import { SwapInput } from "./ui/SwapInput";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { erc20Abi, formatEther, parseEther, Address } from "viem";
+import { useAccount, useConfig, useReadContract } from "wagmi";
+import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
+import MarketABI from "@/abi/market.json";
 
-export const Swapbox = () => {
+const WXDAI_ADDRESS = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+
+// Removes the given fraction from the given integer-bounded amount and returns the value as an original type.
+const removeFraction = (amount: bigint, fraction: number): bigint => {
+  if (fraction >= 1 || fraction <= 0)
+    throw `The given basisPoints ${fraction} is not in the range [0, 1].`;
+
+  const basisPoints = 10000;
+
+  const fractionInBasisPoints = fraction * basisPoints;
+
+  const keepFraction = basisPoints - fractionInBasisPoints;
+
+  return (amount * BigInt(keepFraction)) / BigInt(basisPoints);
+};
+
+export const Swapbox = ({ id }: { id: Address }) => {
+  const { address } = useAccount();
+  const config = useConfig();
+
   const [tokenInAmount, setTokenInAmount] = useState("");
   const [tokenOutAmount, setTokenOutAmount] = useState("");
+  const [minAmountOut, setMinAmountOut] = useState<bigint>();
+
+  const outcomeIndex = 0;
+  const slippage = 0.01;
+
+  const amountWei = parseEther(tokenInAmount);
+
+  const { data: buyAmount } = useReadContract({
+    abi: MarketABI,
+    address: id,
+    functionName: "calcBuyAmount",
+    args: [amountWei, outcomeIndex],
+    query: { enabled: !!tokenInAmount },
+  });
+
+  const { data: allowance, refetch } = useReadContract({
+    abi: erc20Abi,
+    address: WXDAI_ADDRESS,
+    functionName: "allowance",
+    args: [address as Address, id],
+    query: { enabled: !!address },
+  });
+
+  const { data: balance } = useReadContract({
+    abi: erc20Abi,
+    address: WXDAI_ADDRESS,
+    functionName: "balanceOf",
+    args: [address as Address],
+    query: { enabled: !!address },
+  });
+
+  useEffect(() => {
+    if (!buyAmount) return;
+
+    const amountOut = removeFraction(BigInt(buyAmount as bigint), slippage);
+    const twoDigitsAmountOut = parseFloat(formatEther(amountOut)).toFixed(2);
+
+    setMinAmountOut(amountOut);
+    setTokenOutAmount(twoDigitsAmountOut);
+  }, [buyAmount]);
+
+  useEffect(() => {
+    if (tokenInAmount === "") setTokenOutAmount("");
+  }, [tokenInAmount]);
+
+  const approveToken = async () => {
+    try {
+      const txHash = await writeContract(config, {
+        abi: erc20Abi,
+        address: WXDAI_ADDRESS,
+        functionName: "approve",
+        args: [id, amountWei],
+      });
+      await waitForTransactionReceipt(config, {
+        hash: txHash,
+      });
+      refetch();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const submitBet = async () => {
+    try {
+      const txHash = await writeContract(config, {
+        abi: MarketABI,
+        address: id,
+        functionName: "buy",
+        args: [amountWei, outcomeIndex, minAmountOut],
+      });
+      await waitForTransactionReceipt(config, {
+        hash: txHash,
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const maxBalance = () => {
+    setTokenInAmount(formatEther(balance as bigint));
+  };
+
+  const isAllowed = allowance && !!amountWei && allowance >= amountWei;
 
   return (
     <div className="space-y-2 relative">
@@ -17,15 +123,23 @@ export const Swapbox = () => {
           setTokenInAmount(event.target.value);
         }}
         onClick={() => console.log("I want to change token")}
+        selectedToken="wxDAI"
       >
         <div className="flex text-sm items-center justify-end space-x-1.5">
-          <p className="text-text-low-em">Balance: 5400</p>
-          <Button
-            variant="ghost"
-            className="text-sm font-semibold text-text-primary-main"
-          >
-            Use MAX
-          </Button>
+          {!!balance && (
+            <>
+              <p className="text-text-low-em">
+                Balance: {parseFloat(formatEther(balance)).toFixed(2)}
+              </p>
+              <Button
+                variant="ghost"
+                className="text-sm font-semibold text-text-primary-main"
+                onClick={maxBalance}
+              >
+                Use MAX
+              </Button>
+            </>
+          )}
         </div>
       </SwapInput>
       <IconButton
@@ -35,11 +149,25 @@ export const Swapbox = () => {
       />
       <SwapInput
         title="To Receive"
+        selectedToken="YES"
         value={tokenOutAmount}
         onChange={(event) => {
           setTokenOutAmount(event.target.value);
         }}
       />
+      {!tokenInAmount ? (
+        <Button className="w-full" disabled>
+          Enter amount
+        </Button>
+      ) : isAllowed ? (
+        <Button className="w-full" onClick={submitBet}>
+          Bet
+        </Button>
+      ) : (
+        <Button className="w-full" onClick={approveToken}>
+          Allow
+        </Button>
+      )}
     </div>
   );
 };

--- a/app/components/ui/SwapInput.tsx
+++ b/app/components/ui/SwapInput.tsx
@@ -10,6 +10,7 @@ import { Button, Icon, Logo } from "swapr-ui";
 interface SwapInputProps extends PropsWithChildren {
   title: string;
   value?: string;
+  selectedToken?: string;
   onChange?: ChangeEventHandler<HTMLInputElement>;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
@@ -20,6 +21,7 @@ export const SwapInput = ({
   value,
   onChange,
   onClick,
+  selectedToken,
 }: SwapInputProps) => {
   return (
     <div className="p-4 space-y-1 bg-surface-surface-1 rounded-16">
@@ -46,7 +48,7 @@ export const SwapInput = ({
             alt="token logo"
             size="xs"
           />
-          <p className="font-semibold">SDAI</p>
+          <p className="font-semibold">{selectedToken}</p>
           <Icon name="chevron-down" />
         </Button>
       </div>

--- a/app/markets/[id]/MarketDetails.tsx
+++ b/app/markets/[id]/MarketDetails.tsx
@@ -6,9 +6,10 @@ import { getMarket } from "@/queries/omen";
 import { Button, IconButton, Tag } from "swapr-ui";
 import { remainingTime } from "@/utils/dates";
 import Link from "next/link";
+import { Address } from "viem";
 
 interface MarketDetailsProps {
-  id: string;
+  id: Address;
 }
 
 export const MarketDetails = ({ id }: MarketDetailsProps) => {
@@ -65,7 +66,7 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           </div>
         </div>
         <div className="p-2">
-          <Swapbox />
+          <Swapbox id={id} />
         </div>
       </div>
     </div>

--- a/app/markets/[id]/page.tsx
+++ b/app/markets/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
   getMarkets,
 } from "@/queries/omen";
 import { MarketDetails } from "./MarketDetails";
+import { Address } from "viem";
 
 // Return a list of `params` to populate the [slug] dynamic segment
 export async function generateStaticParams() {
@@ -13,7 +14,7 @@ export async function generateStaticParams() {
     queryKey: ["getMarkets"],
     queryFn: async () =>
       getMarkets({
-        first: 10,
+        first: 100,
         skip: 0,
         orderBy: FixedProductMarketMaker_OrderBy.CreationTimestamp,
         orderDirection: OrderDirection.Desc,
@@ -28,7 +29,7 @@ export async function generateStaticParams() {
 export default async function MarketsPage({
   params,
 }: {
-  params: { id: string };
+  params: { id: Address };
 }) {
   return (
     <main className="w-full px-6 mt-16 flex flex-col items-center">

--- a/app/my-bets/page.tsx
+++ b/app/my-bets/page.tsx
@@ -4,22 +4,28 @@ import { CardBet, LoadingCardBet } from "@/app/components/CardBet";
 import {
   FixedProductMarketMaker_OrderBy,
   OrderDirection,
-  getMarkets,
+  getAccountMarkets,
 } from "@/queries/omen";
 import { useQuery } from "@tanstack/react-query";
 import { TabBody, TabGroup, TabHeader, TabPanel, TabStyled } from "swapr-ui";
+import { useAccount } from "wagmi";
 
 export default function MyBetsPage() {
-  const { data: markets, isLoading } = useQuery({
-    queryKey: ["getMarkets"],
+  const { address } = useAccount();
+  const { data: accountMarkets, isLoading } = useQuery({
+    queryKey: ["getAccountMarkets"],
     queryFn: async () =>
-      getMarkets({
+      getAccountMarkets({
         first: 10,
         skip: 0,
         orderBy: FixedProductMarketMaker_OrderBy.CreationTimestamp,
         orderDirection: OrderDirection.Desc,
+        id: address?.toLowerCase() as string,
       }),
+    enabled: !!address,
   });
+
+  const markets = accountMarkets?.account?.fpmmParticipations;
 
   return (
     <div className="w-full px-6 mt-12 space-y-12 md:items-center md:flex md:flex-col">
@@ -46,12 +52,12 @@ export default function MyBetsPage() {
             <TabBody className="mt-8">
               <TabPanel className="space-y-4">
                 {isLoading
-                  ? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(index => (
+                  ? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((index) => (
                       <LoadingCardBet key={index} />
                     ))
-                  : markets?.fixedProductMarketMakers &&
-                    markets.fixedProductMarketMakers.map(market => (
-                      <CardBet market={market} key={market.id} />
+                  : markets &&
+                    markets.map((market) => (
+                      <CardBet market={market.fpmm} key={market.id} />
                     ))}
               </TabPanel>
               <TabPanel>

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -1,6 +1,9 @@
 import { gql, request } from "graphql-request";
 import {
+  FixedProductMarketMaker_Filter,
+  InputMaybe,
   Query,
+  QueryAccountArgs,
   QueryFixedProductMarketMakerArgs,
   QueryFixedProductMarketMakersArgs,
 } from "./types";
@@ -137,6 +140,76 @@ const getMarketsQuery = gql`
   }
 `;
 
+const getAccountMarketsQuery = gql`
+  query GetMyMarkets(
+    $id: String!
+    $first: Int!
+    $skip: Int!
+    $orderBy: String
+    $orderDirection: String
+  ) {
+    account(id: $id) {
+      fpmmParticipations(
+        first: $first
+        skip: $skip
+        orderBy: $orderBy
+        orderDirection: $orderDirection
+      ) {
+        fpmm: fpmm {
+          ...marketData
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+  }
+
+  fragment marketData on FixedProductMarketMaker {
+    id
+    collateralVolume
+    collateralToken
+    creationTimestamp
+    lastActiveDay
+    outcomeTokenAmounts
+    runningDailyVolumeByHour
+    scaledLiquidityParameter
+    title
+    outcomes
+    openingTimestamp
+    arbitrator
+    category
+    templateId
+    scaledLiquidityParameter
+    curatedByDxDao
+    klerosTCRregistered
+    outcomeTokenMarginalPrices
+    condition {
+      id
+      oracle
+      scalarLow
+      scalarHigh
+      __typename
+    }
+    question {
+      id
+      data
+      currentAnswer
+      outcomes
+      answers {
+        answer
+        bondAggregate
+        __typename
+      }
+      __typename
+    }
+    outcomes
+    outcomeTokenMarginalPrices
+    usdVolume
+    __typename
+  }
+`;
+
 const getMarket = async (params: QueryFixedProductMarketMakerArgs) =>
   request<Pick<Query, "fixedProductMarketMaker">>(
     OMEN_SUBGRAPH_URL,
@@ -151,4 +224,13 @@ const getMarkets = async (params: QueryFixedProductMarketMakersArgs) =>
     params
   );
 
-export { getMarket, getMarkets };
+const getAccountMarkets = async (
+  params: QueryAccountArgs & QueryFixedProductMarketMakersArgs
+) =>
+  request<Pick<Query, "account">>(
+    OMEN_SUBGRAPH_URL,
+    getAccountMarketsQuery,
+    params
+  );
+
+export { getMarket, getMarkets, getAccountMarkets };


### PR DESCRIPTION
- Add betting logic to Swapbox
- Adds query to filter account's markets

![image](https://github.com/SwaprHQ/presagio/assets/23079677/e1547117-8180-4aea-aa71-ed50a48320e7)
