### PR TITLE
Add TxContext to abstract writeContract with TX modal - submitTx

### DIFF
--- a/app/components/CardBet.tsx
+++ b/app/components/CardBet.tsx
@@ -21,7 +21,7 @@ import { redeemPositions } from "@/hooks/contracts";
 import { WXDAI } from "@/constants";
 import { waitForTransactionReceipt } from "wagmi/actions";
 import { useState } from "react";
-import { ModalId, useModalContext } from "@/context/ModalContext";
+import { ModalId, useModal } from "@/context/ModalContext";
 import { TransactionModal } from "./TransactionModal";
 
 interface BetProps {
@@ -36,7 +36,7 @@ export const CardBet = ({ userPosition }: BetProps) => {
   const { address } = useAccount();
   const [txHash, setTxHash] = useState("");
   const [isTxLoading, setIsTxLoading] = useState(false);
-  const { openModal } = useModalContext();
+  const { openModal } = useModal();
 
   const { data, isLoading } = useQuery({
     queryKey: ["getConditionMarket", position.conditionId],

--- a/app/components/ConfirmTrade.tsx
+++ b/app/components/ConfirmTrade.tsx
@@ -1,4 +1,4 @@
-import { ModalId, useModalContext } from "@/context/ModalContext";
+import { ModalId, useModal } from "@/context/ModalContext";
 import {
   Button,
   Dialog,
@@ -44,7 +44,7 @@ export const ConfirmTrade = ({
   tokenAmountIn,
   tokenAmountOut,
 }: ConfirmTradeProps) => {
-  const { isModalOpen, closeModal } = useModalContext();
+  const { isModalOpen, closeModal } = useModal();
   const { submitTx } = useTx();
 
   const { data: sellAmount } = useReadCalcSellAmount(

--- a/app/components/ConfirmTrade.tsx
+++ b/app/components/ConfirmTrade.tsx
@@ -10,8 +10,6 @@ import {
   Icon,
 } from "swapr-ui";
 import { SLIPPAGE, SwapDirection, SwapState } from ".";
-import { useState } from "react";
-import { waitForTransactionReceipt, writeContract } from "wagmi/actions";
 import MarketABI from "@/abi/market.json";
 import {
   CONDITIONAL_TOKEN_CONTRACT_ADDRESS,
@@ -19,10 +17,9 @@ import {
 } from "@/hooks/contracts";
 import ConditionalTokensABI from "@/abi/conditionalTokens.json";
 import { addFraction, removeFraction } from "@/utils/price";
-import { useConfig } from "wagmi";
-import { Address, erc20Abi, formatEther, parseEther } from "viem";
+import { Abi, Address, erc20Abi, formatEther, parseEther } from "viem";
 import { WXDAI } from "@/constants";
-import { TransactionModal } from "./TransactionModal";
+import { useTx } from "@/context";
 
 const ROUNDING_PRECISON = 0.00000000001;
 
@@ -47,10 +44,9 @@ export const ConfirmTrade = ({
   tokenAmountIn,
   tokenAmountOut,
 }: ConfirmTradeProps) => {
-  const config = useConfig();
-  const { isModalOpen, openModal, closeModal } = useModalContext();
-  const [txHash, setTxHash] = useState("");
-  const [isTxLoading, setIsTxLoading] = useState(false);
+  const { isModalOpen, closeModal } = useModalContext();
+  const { submitTx } = useTx();
+
   const { data: sellAmount } = useReadCalcSellAmount(
     marketId,
     formatEther(tokenAmountOut || BigInt(0)),
@@ -59,10 +55,6 @@ export const ConfirmTrade = ({
 
   const closeBetModal = () => {
     closeModal(ModalId.CONFIRM_SWAP);
-  };
-
-  const openTxModal = () => {
-    openModal(ModalId.WAITING_TRANSACTION);
   };
 
   const amountWei = parseEther(tokenAmountIn);
@@ -74,102 +66,54 @@ export const ConfirmTrade = ({
     : "";
 
   const approveToken = async () => {
-    setIsTxLoading(true);
-
-    try {
-      const txHash = await writeContract(config, {
-        abi: erc20Abi,
-        address: WXDAI.address,
-        functionName: "approve",
-        args: [marketId, amountWei],
-      });
-      setTxHash(txHash);
-      openTxModal();
-
-      await waitForTransactionReceipt(config, {
-        hash: txHash,
-      });
+    submitTx({
+      abi: erc20Abi,
+      address: WXDAI.address,
+      functionName: "approve",
+      args: [marketId, amountWei],
+    }).then(() => {
       onApprove();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsTxLoading(false);
-    }
+    });
   };
 
   const approveNFT = async () => {
-    setIsTxLoading(true);
-    try {
-      const txHash = await writeContract(config, {
-        abi: ConditionalTokensABI,
-        address: CONDITIONAL_TOKEN_CONTRACT_ADDRESS,
-        functionName: "setApprovalForAll",
-        args: [marketId, true],
-      });
-      setTxHash(txHash);
-      openTxModal();
-
-      await waitForTransactionReceipt(config, {
-        hash: txHash,
-      });
+    submitTx({
+      abi: ConditionalTokensABI as Abi,
+      address: CONDITIONAL_TOKEN_CONTRACT_ADDRESS,
+      functionName: "setApprovalForAll",
+      args: [marketId, true],
+    }).then(() => {
       onApprove();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsTxLoading(false);
-    }
+    });
   };
 
   const submitBuyBet = async () => {
-    setIsTxLoading(true);
-    try {
-      const txHash = await writeContract(config, {
-        abi: MarketABI,
-        address: marketId,
-        functionName: "buy",
-        args: [amountWei, outcomeIndex, tokenAmountOut],
-      });
-      setTxHash(txHash);
+    submitTx({
+      abi: MarketABI as Abi,
+      address: marketId,
+      functionName: "buy",
+      args: [amountWei, outcomeIndex, tokenAmountOut],
+    }).then(() => {
       closeBetModal();
-      openTxModal();
-
-      await waitForTransactionReceipt(config, {
-        hash: txHash,
-      });
       onSwap();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsTxLoading(false);
-    }
+    });
   };
 
   const submitSellBet = async () => {
     if (!tokenAmountOut || !sellAmount) return;
 
-    setIsTxLoading(true);
     const roundedAmountOut = removeFraction(tokenAmountOut, ROUNDING_PRECISON);
     const maxSellAmount = addFraction(sellAmount as bigint, SLIPPAGE);
 
-    try {
-      const txHash = await writeContract(config, {
-        abi: MarketABI,
-        address: marketId,
-        functionName: "sell",
-        args: [roundedAmountOut, outcomeIndex, maxSellAmount],
-      });
-      setTxHash(txHash);
+    submitTx({
+      abi: MarketABI as Abi,
+      address: marketId,
+      functionName: "sell",
+      args: [roundedAmountOut, outcomeIndex, maxSellAmount],
+    }).then(() => {
       closeBetModal();
-      openTxModal();
-      await waitForTransactionReceipt(config, {
-        hash: txHash,
-      });
       onSwap();
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsTxLoading(false);
-    }
+    });
   };
 
   const confirmState = {
@@ -180,90 +124,87 @@ export const ConfirmTrade = ({
   const currentConfirmState = confirmState[swapDirection];
 
   return (
-    <>
-      <Dialog
-        open={isModalOpen(ModalId.CONFIRM_SWAP)}
-        onOpenChange={closeBetModal}
-      >
-        <DialogContent>
-          <DialogHeader size="xl" className="text-center">
-            <DialogClose position="left" size="xl">
-              <Button variant="ghost">
-                <Icon name="arrow-left" />
-              </Button>
-            </DialogClose>
-            Confirm Swap
-          </DialogHeader>
-          <DialogBody className="px-2 space-y-2">
-            <div className="relative bg-surface-surface-1 rounded-16">
-              <div className="border-b-[1px] border-b-outline-base-em w-full flex flex-col items-center pt-3 pb-8 space-y-1">
-                <p className="text-xs uppercase text-text-low-em">You sell</p>
-                <div className="text-2xl uppercase">
-                  <span>{twoDecimalsTokenAmountIn}</span>{" "}
-                  <span className="text-text-low-em">
-                    {swapState.inToken.symbol}
-                  </span>
-                </div>
-              </div>
-              <div className="flex items-center justify-center rounded-100 bg-surface-surface-3 h-[40px] w-[56px] absolute top-[calc(50%_-_20px)] left-[calc(50%_-_28px)]">
-                <Icon name="arrow-down" />
-              </div>
-              <div className="flex flex-col items-center w-full pt-8 pb-3 space-y-1">
-                <p className="text-xs uppercase text-text-low-em">You buy</p>
-                <div className="text-2xl uppercase">
-                  <span>{twoDecimalsTokenAmountOut}</span>{" "}
-                  <span className="text-text-low-em">
-                    {swapState.outToken.symbol}
-                  </span>
-                </div>
+    <Dialog
+      open={isModalOpen(ModalId.CONFIRM_SWAP)}
+      onOpenChange={closeBetModal}
+    >
+      <DialogContent>
+        <DialogHeader size="xl" className="text-center">
+          <DialogClose position="left" size="xl">
+            <Button variant="ghost">
+              <Icon name="arrow-left" />
+            </Button>
+          </DialogClose>
+          Confirm Swap
+        </DialogHeader>
+        <DialogBody className="px-2 space-y-2">
+          <div className="relative bg-surface-surface-1 rounded-16">
+            <div className="border-b-[1px] border-b-outline-base-em w-full flex flex-col items-center pt-3 pb-8 space-y-1">
+              <p className="text-xs uppercase text-text-low-em">You sell</p>
+              <div className="text-2xl uppercase">
+                <span>{twoDecimalsTokenAmountIn}</span>{" "}
+                <span className="text-text-low-em">
+                  {swapState.inToken.symbol}
+                </span>
               </div>
             </div>
-            <div className="border border-outline-base-em rounded-12">
-              <div className="px-3 py-1">
-                <div className="flex items-center justify-between">
-                  <p className=" text-text-low-em">Price</p>
-                  <div className="flex items-center space-x-1">
-                    <p>1 {swapState.inToken.symbol}</p>
-                    <p>=</p>
-                    <p className="text-text-success-em">
-                      {swapState.tokenPrice} {swapState.outToken.symbol}
-                    </p>
-                    <p className=" text-text-low-em">(≈ $1)</p>
-                  </div>
-                </div>
-                <div className="flex items-center justify-between">
-                  <p className=" text-text-low-em">Slippage</p>
-                  <p>{SLIPPAGE * 100}%</p>
-                </div>
+            <div className="flex items-center justify-center rounded-100 bg-surface-surface-3 h-[40px] w-[56px] absolute top-[calc(50%_-_20px)] left-[calc(50%_-_28px)]">
+              <Icon name="arrow-down" />
+            </div>
+            <div className="flex flex-col items-center w-full pt-8 pb-3 space-y-1">
+              <p className="text-xs uppercase text-text-low-em">You buy</p>
+              <div className="text-2xl uppercase">
+                <span>{twoDecimalsTokenAmountOut}</span>{" "}
+                <span className="text-text-low-em">
+                  {swapState.outToken.symbol}
+                </span>
               </div>
             </div>
-          </DialogBody>
-          <DialogFooter>
-            {!swapState.isAllowed && (
-              <Button
-                width="full"
-                colorScheme="success"
-                variant="pastel"
-                onClick={currentConfirmState.approve}
-                size="lg"
-              >
-                Approve
-              </Button>
-            )}
+          </div>
+          <div className="border border-outline-base-em rounded-12">
+            <div className="px-3 py-1">
+              <div className="flex items-center justify-between">
+                <p className=" text-text-low-em">Price</p>
+                <div className="flex items-center space-x-1">
+                  <p>1 {swapState.inToken.symbol}</p>
+                  <p>=</p>
+                  <p className="text-text-success-em">
+                    {swapState.tokenPrice} {swapState.outToken.symbol}
+                  </p>
+                  <p className=" text-text-low-em">(≈ $1)</p>
+                </div>
+              </div>
+              <div className="flex items-center justify-between">
+                <p className=" text-text-low-em">Slippage</p>
+                <p>{SLIPPAGE * 100}%</p>
+              </div>
+            </div>
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          {!swapState.isAllowed && (
             <Button
               width="full"
               colorScheme="success"
               variant="pastel"
-              onClick={currentConfirmState.submit}
-              disabled={!swapState.isAllowed}
+              onClick={currentConfirmState.approve}
               size="lg"
             >
-              Confirm Swap
+              Approve
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <TransactionModal isLoading={isTxLoading} txHash={txHash} />
-    </>
+          )}
+          <Button
+            width="full"
+            colorScheme="success"
+            variant="pastel"
+            onClick={currentConfirmState.submit}
+            disabled={!swapState.isAllowed}
+            size="lg"
+          >
+            Confirm Swap
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/app/components/Swapbox.tsx
+++ b/app/components/Swapbox.tsx
@@ -20,7 +20,7 @@ import {
   removeFraction,
 } from "@/utils/price";
 import { ConfirmTrade } from "./ConfirmTrade";
-import { ModalId, useModalContext } from "@/context/ModalContext";
+import { ModalId, useModal } from "@/context/ModalContext";
 import { WXDAI } from "@/constants";
 
 export const SLIPPAGE = 0.01;
@@ -51,7 +51,7 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
   const outcome1 = new Outcome(1, market.outcomes?.[1] || "Option 2", id);
 
   const { address, isDisconnected } = useAccount();
-  const { openModal } = useModalContext();
+  const { openModal } = useModal();
 
   const [tokenAmountIn, setTokenAmountIn] = useState("");
   const [tokenAmountOut, setTokenAmountOut] = useState<bigint>();

--- a/app/components/TransactionModal.tsx
+++ b/app/components/TransactionModal.tsx
@@ -8,7 +8,7 @@ import {
   Icon,
   IconBadge,
 } from "swapr-ui";
-import { ModalId, useModalContext } from "@/context/ModalContext";
+import { ModalId, useModal } from "@/context/ModalContext";
 import Image from "next/image";
 
 interface TransactionModalProps {
@@ -22,7 +22,7 @@ export const TransactionModal = ({
   txHash,
   isError,
 }: TransactionModalProps) => {
-  const { isModalOpen, closeModal } = useModalContext();
+  const { isModalOpen, closeModal } = useModal();
 
   const close = () => {
     closeModal(ModalId.WAITING_TRANSACTION);

--- a/app/components/TransactionModal.tsx
+++ b/app/components/TransactionModal.tsx
@@ -56,30 +56,35 @@ export const TransactionModal = ({
                   </p>
                 </div>
               </>
-            ) : isError ? (
-              <>
-                <IconBadge name="exclamation" colorScheme="error" />
-                <div className="flex flex-col items-center space-y-2">
-                  <p className="text-2xl font-semibold text-text-high-em">
-                    There was an error.
-                  </p>
-                  <p className="font-semibold text-center text-text-low-em text-md max-w-80">
-                    Unfortunately the transaction was not completed.
-                  </p>
-                </div>
-              </>
             ) : (
               <>
-                <IconBadge name="tick" colorScheme="success" />
-                <div className="flex flex-col items-center space-y-2">
-                  <p className="text-2xl font-semibold text-text-high-em">
-                    Transaction successful!
-                  </p>
-                  <p className="font-semibold text-center text-text-low-em text-md max-w-80">
-                    The transaction has been completed. <br />
-                    You can close this window now.
-                  </p>
-                </div>
+                {!isError && (
+                  <>
+                    <IconBadge name="tick" colorScheme="success" />
+                    <div className="flex flex-col items-center space-y-2">
+                      <p className="text-2xl font-semibold text-text-high-em">
+                        Transaction successful!
+                      </p>
+                      <p className="font-semibold text-center text-text-low-em text-md max-w-80">
+                        The transaction has been completed. <br />
+                        You can close this window now.
+                      </p>
+                    </div>
+                  </>
+                )}
+                {isError && (
+                  <>
+                    <IconBadge name="exclamation" colorScheme="error" />
+                    <div className="flex flex-col items-center space-y-2">
+                      <p className="text-2xl font-semibold text-text-high-em">
+                        There was an error.
+                      </p>
+                      <p className="font-semibold text-center text-text-low-em text-md max-w-80">
+                        Unfortunately the transaction was not completed.
+                      </p>
+                    </div>
+                  </>
+                )}
               </>
             )}
           </div>
@@ -90,6 +95,7 @@ export const TransactionModal = ({
               href={`https://gnosisscan.io/tx/${txHash}`}
               target="_blank"
               className="w-full"
+              rel="noopener noreferrer"
             >
               <Button
                 width="full"

--- a/app/components/TransactionModal.tsx
+++ b/app/components/TransactionModal.tsx
@@ -13,12 +13,14 @@ import Image from "next/image";
 
 interface TransactionModalProps {
   isLoading: boolean;
+  isError?: boolean;
   txHash?: string;
 }
 
 export const TransactionModal = ({
   isLoading,
   txHash,
+  isError,
 }: TransactionModalProps) => {
   const { isModalOpen, closeModal } = useModalContext();
 
@@ -31,7 +33,7 @@ export const TransactionModal = ({
       open={isModalOpen(ModalId.WAITING_TRANSACTION)}
       onOpenChange={close}
     >
-      <DialogContent className="">
+      <DialogContent>
         <DialogHeader />
         <DialogBody className="max-w-[496px] w-[496px] px-2 space-y-2 mt-8 mb-8">
           <div className="flex flex-col items-center w-full space-y-20">
@@ -54,6 +56,18 @@ export const TransactionModal = ({
                   </p>
                 </div>
               </>
+            ) : isError ? (
+              <>
+                <IconBadge name="exclamation" colorScheme="error" />
+                <div className="flex flex-col items-center space-y-2">
+                  <p className="text-2xl font-semibold text-text-high-em">
+                    There was an error.
+                  </p>
+                  <p className="font-semibold text-center text-text-low-em text-md max-w-80">
+                    Unfortunately the transaction was not completed.
+                  </p>
+                </div>
+              </>
             ) : (
               <>
                 <IconBadge name="tick" colorScheme="success" />
@@ -71,19 +85,26 @@ export const TransactionModal = ({
           </div>
         </DialogBody>
         <DialogFooter>
-          <Button
-            width="full"
-            colorScheme={isLoading ? "primary" : "success"}
-            variant="pastel"
-            onClick={() =>
-              window.open(`https://gnosisscan.io/tx/${txHash}`, "_blank")
-            }
-            size="lg"
-          >
-            <>
-              View in explorer <Icon name="arrow-top-right" />
-            </>
-          </Button>
+          {txHash && (
+            <a
+              href={`https://gnosisscan.io/tx/${txHash}`}
+              target="_blank"
+              className="w-full"
+            >
+              <Button
+                width="full"
+                colorScheme={
+                  isLoading ? "primary" : isError ? "error" : "success"
+                }
+                variant="pastel"
+                size="lg"
+              >
+                <>
+                  View in explorer <Icon name="arrow-top-right" />
+                </>
+              </Button>
+            </a>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import { Button, Icon, Logo, Tag } from "swapr-ui";
 import { WXDAI } from "@/constants";
 import { TransactionModal } from ".";
-import { ModalId, useModalContext } from "@/context/ModalContext";
+import { ModalId, useModal } from "@/context/ModalContext";
 import { config } from "@/providers/config";
 import { redeemPositions, useReadBalance } from "@/hooks/contracts";
 import { getCondition } from "@/queries/conditional-tokens";
@@ -22,7 +22,7 @@ export const UserBets = ({ market }: UserBets) => {
   const conditionId = market.condition?.id;
 
   const { address } = useAccount();
-  const { openModal } = useModalContext();
+  const { openModal } = useModal();
 
   const [txHash, setTxHash] = useState("");
   const [isTxLoading, setIsTxLoading] = useState(false);

--- a/context/ModalContext.tsx
+++ b/context/ModalContext.tsx
@@ -30,7 +30,7 @@ export const ModalContext = createContext<ModalContextProps>({
   isModalOpen: (id: ModalId) => false,
 });
 
-export interface ModalContextProviderProps {
+export interface ModalProviderProps {
   children: ReactNode;
 }
 
@@ -51,9 +51,7 @@ function ModalReducer(openModals: ModalId[], action: Action) {
   }
 }
 
-export const ModalContextProvider = ({
-  children,
-}: ModalContextProviderProps) => {
+export const ModalProvider = ({ children }: ModalProviderProps) => {
   const [openModals, dispatch] = useReducer(ModalReducer, []);
 
   const openModal = (modalId: ModalId) => {
@@ -87,4 +85,4 @@ export const ModalContextProvider = ({
   );
 };
 
-export const useModalContext = () => useContext(ModalContext);
+export const useModal = () => useContext(ModalContext);

--- a/context/TxContext.tsx
+++ b/context/TxContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ModalId, useModalContext } from "@/context/ModalContext";
+import { ModalId, useModal } from "@/context/ModalContext";
 import { PropsWithChildren, createContext, useContext, useState } from "react";
 import { waitForTransactionReceipt } from "@wagmi/core";
 import { type WriteContractParameters, type Config } from "@wagmi/core";
@@ -22,7 +22,7 @@ export const TxProvider = ({ children }: PropsWithChildren) => {
   const [isTxLoading, setIsTxLoading] = useState(false);
   const [isError, setIsError] = useState(false);
 
-  const { openModal } = useModalContext();
+  const { openModal } = useModal();
 
   const submitTx = async (args: WriteContractParameters): Promise<void> => {
     setIsTxLoading(true);

--- a/context/TxContext.tsx
+++ b/context/TxContext.tsx
@@ -41,7 +41,6 @@ export const TxProvider = ({ children }: PropsWithChildren) => {
     } catch (error) {
       setIsError(true);
       console.error(error);
-      throw error;
     } finally {
       setIsTxLoading(false);
     }

--- a/context/TxContext.tsx
+++ b/context/TxContext.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ModalId, useModalContext } from "@/context/ModalContext";
+import { PropsWithChildren, createContext, useContext, useState } from "react";
+import { waitForTransactionReceipt } from "@wagmi/core";
+import { type WriteContractParameters, type Config } from "@wagmi/core";
+
+import { writeContract } from "wagmi/actions";
+import { TransactionModal } from "@/app/components";
+import { config } from "@/providers/config";
+
+export interface TxContextProps {
+  submitTx: (args: WriteContractParameters) => Promise<void>;
+}
+
+export const TxContext = createContext<TxContextProps>({
+  submitTx: async (args: WriteContractParameters) => {},
+});
+
+export const TxProvider = ({ children }: PropsWithChildren) => {
+  const [txHash, setTxHash] = useState<string>("");
+  const [isTxLoading, setIsTxLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const { openModal } = useModalContext();
+
+  const submitTx = async (args: WriteContractParameters): Promise<void> => {
+    setIsTxLoading(true);
+    setIsError(false);
+    setTxHash("");
+
+    try {
+      const txHash = await writeContract(config, args);
+      setTxHash(txHash);
+
+      openModal(ModalId.WAITING_TRANSACTION);
+
+      await waitForTransactionReceipt(config, {
+        hash: txHash,
+      });
+    } catch (error) {
+      setIsError(true);
+      console.error(error);
+      throw error;
+    } finally {
+      setIsTxLoading(false);
+    }
+  };
+
+  const txContext = {
+    submitTx,
+  };
+
+  return (
+    <TxContext.Provider value={txContext}>
+      {children}
+      <TransactionModal
+        isLoading={isTxLoading}
+        txHash={txHash}
+        isError={isError}
+      />
+    </TxContext.Provider>
+  );
+};
+
+export const useTx = () => useContext(TxContext);

--- a/context/index.ts
+++ b/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./ModalContext";
+export * from "./TxContext";

--- a/providers/providers.tsx
+++ b/providers/providers.tsx
@@ -7,7 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { config } from "./config";
 import { ConnectKitProvider } from "connectkit";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
-import { TxProvider, ModalContextProvider } from "@/context";
+import { TxProvider, ModalProvider } from "@/context";
 
 const queryClient = new QueryClient();
 
@@ -20,11 +20,11 @@ export const Providers = ({ children }: PropsWithChildren) => {
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
         <ConnectKitProvider options={connectKitOptions}>
-          <ModalContextProvider>
-            <TxProvider>
+          <TxProvider>
+            <ModalProvider>
               <NextThemesProvider>{children}</NextThemesProvider>
-            </TxProvider>
-          </ModalContextProvider>
+            </ModalProvider>
+          </TxProvider>
         </ConnectKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/providers/providers.tsx
+++ b/providers/providers.tsx
@@ -20,11 +20,11 @@ export const Providers = ({ children }: PropsWithChildren) => {
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
         <ConnectKitProvider options={connectKitOptions}>
-          <TxProvider>
-            <ModalProvider>
+          <ModalProvider>
+            <TxProvider>
               <NextThemesProvider>{children}</NextThemesProvider>
-            </ModalProvider>
-          </TxProvider>
+            </TxProvider>
+          </ModalProvider>
         </ConnectKitProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/providers/providers.tsx
+++ b/providers/providers.tsx
@@ -6,8 +6,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { config } from "./config";
 import { ConnectKitProvider } from "connectkit";
-import { ModalContextProvider } from "@/context/ModalContext";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
+import { TxProvider, ModalContextProvider } from "@/context";
 
 const queryClient = new QueryClient();
 
@@ -21,7 +21,9 @@ export const Providers = ({ children }: PropsWithChildren) => {
       <QueryClientProvider client={queryClient}>
         <ConnectKitProvider options={connectKitOptions}>
           <ModalContextProvider>
-            <NextThemesProvider>{children}</NextThemesProvider>
+            <TxProvider>
+              <NextThemesProvider>{children}</NextThemesProvider>
+            </TxProvider>
           </ModalContextProvider>
         </ConnectKitProvider>
       </QueryClientProvider>


### PR DESCRIPTION
### TxProvider

this provider wraps wagmi's `writeContract` method with the `TransactionModal` to show feedback from the written transaction: loading/success/error and also links to explorer.

**API**
`submitTx` - call writeContract, shows modal with tx

**TransactionModal**
Modal with transaction feedback 
- tx state: loading/success/error
- tx explorer link

<img width="857" alt="image" src="https://github.com/SwaprHQ/presagio/assets/5664434/6f98d999-0b8d-484a-a8a0-3cbf7566d6e7">

<img width="718" alt="image" src="https://github.com/SwaprHQ/presagio/assets/5664434/f5d24cdb-bf57-4dfe-84e1-4ad30bfa9ca1">
