### PR TITLE
Allow filtering markets by categories (functionality)

### DIFF
--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -85,6 +85,7 @@ const getMarketsQuery = gql`
     $orderDirection: String
     $title_contains_nocase: String
     $creator_in: [String]
+    $category_contains: String
   ) {
     fixedProductMarketMakers(
       first: $first
@@ -95,6 +96,7 @@ const getMarketsQuery = gql`
         outcomeSlotCount: 2
         title_contains_nocase: $title_contains_nocase
         creator_in: $creator_in
+        category_contains: $category_contains
       }
     ) {
       ...marketData


### PR DESCRIPTION
This PR takes care of the initial functionality of categories. 
It allows filtering markets by a category at a time.

The design from Akash uses Tabs component but Tabs implies that we render content related to the tab, in this case we just want to choose an option from several options which is our `ToggleGroup` component does. 

So we'll go with that and then we can add a diff component to swapr-ui or just have diff design option to ToggleGroup, we should explore options.

**Current design**
<img width="1897" alt="image" src="https://github.com/SwaprHQ/presagio/assets/5664434/eebf4607-e59b-49f8-a651-105e74c81f65">
