### PR TITLE
Show activity on Market - list of user trades  (UI)

### DIFF
--- a/app/components/ui/Table.tsx
+++ b/app/components/ui/Table.tsx
@@ -1,0 +1,119 @@
+import { cx } from "class-variance-authority";
+import * as React from "react";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cx("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cx("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cx("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cx(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cx(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted border-outline-base-em",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cx(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cx(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cx("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/app/markets/ActivityTable.tsx
+++ b/app/markets/ActivityTable.tsx
@@ -1,0 +1,88 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/app/components/ui/Table";
+import { formatDateTime, shortenAddress } from "@/utils";
+import { Tag } from "swapr-ui";
+
+const activities = [
+  {
+    user: "0x8a05649a4fa186d032376f6d34f6bf40ca0168ae",
+    action: "Yes",
+    shares: "1.24",
+    date: 1718999911,
+  },
+  {
+    user: "0x1b3bbecdcb76594e1dc5f7550263cd5ea4a6ab6d",
+    action: "No",
+    shares: "2.3",
+    date: 1718999111,
+  },
+  {
+    user: "0x7532a3ce4d80cc3fb71d69a5329f76f9f375aa27",
+    action: "Yes",
+    shares: "32.2",
+    date: 1718912111,
+  },
+  {
+    user: "0x2fe3e7422f35ecbb9dca542279fb2ee172faab32",
+    action: "Yes",
+    shares: 23.1,
+    date: 1718903353,
+  },
+  {
+    user: "0x269e4c1cb7d8586a99baca522db8c2ef72bbf3ac",
+    action: "No",
+    shares: 12.2,
+    date: 1718901111,
+  },
+  {
+    user: "0xf9d7aeaa523906f59070eee225f16c7893e2b262",
+    action: "Yes",
+    shares: 0.42,
+    date: 1718801111,
+  },
+];
+
+export const ActivityTable = () => {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="text-text-low-em">Users</TableHead>
+          <TableHead className="text-text-low-em">Action</TableHead>
+          <TableHead className="text-text-low-em">Shares</TableHead>
+          <TableHead className="text-right text-text-low-em">Date</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody className="text-base font-semibold">
+        {activities.map(activity => (
+          <TableRow key={activity.user}>
+            <TableCell className="text-text-high-em">
+              {shortenAddress(activity.user)}
+            </TableCell>
+            <TableCell className="">
+              <Tag
+                size="xs"
+                colorScheme={activity.action === "Yes" ? "success" : "danger"}
+                className="uppercase w-fit"
+              >
+                {activity.action}
+              </Tag>
+            </TableCell>
+            <TableCell className="text-text-high-em">
+              {activity.shares}
+            </TableCell>
+            <TableCell className="text-right text-text-low-em">
+              {formatDateTime(activity.date)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/app/markets/HistorySection.tsx
+++ b/app/markets/HistorySection.tsx
@@ -1,3 +1,4 @@
+import { ActivityTable } from "@/app/markets/ActivityTable";
 import {
   Icon,
   TabBody,
@@ -10,11 +11,7 @@ import {
 export const HistorySection = () => {
   return (
     <div className="p-2">
-      <TabGroup
-        onChange={(index: number) =>
-          console.log("Changed selected tab to:", index)
-        }
-      >
+      <TabGroup>
         <TabHeader className="overflow-x-auto md:overflow-x-visible">
           <TabStyled className="space-x-2">
             <Icon size={18} name="activity"></Icon>
@@ -27,14 +24,7 @@ export const HistorySection = () => {
         </TabHeader>
         <TabBody className="my-4">
           <TabPanel>
-            <div className="bg-surface-surface-2 h-44 rounded-8">
-              <div className="flex items-center justify-center h-full">
-                <div className="flex flex-col items-center space-y-2">
-                  <Icon name="filter" size={24} />
-                  <p>Activity coming soon</p>
-                </div>
-              </div>
-            </div>
+            <ActivityTable />
           </TabPanel>
           <TabPanel>
             <div className="bg-surface-surface-2 h-44 rounded-8">

--- a/utils/dates.ts
+++ b/utils/dates.ts
@@ -1,4 +1,4 @@
-import { formatDistance, isPast } from "date-fns";
+import { formatDistance, isPast, fromUnixTime, format } from "date-fns";
 
 export const remainingTime = (date: Date): string => {
   const now: Date = new Date();
@@ -8,4 +8,10 @@ export const remainingTime = (date: Date): string => {
   } else {
     return `${formatDistance(date, now)} remaining`;
   }
+};
+
+export const formatDateTime = (timestamp: number) => {
+  const date = fromUnixTime(timestamp);
+  const formattedDate = format(date, "d MMM- HH:mm");
+  return formattedDate;
 };

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,4 @@
+export * from "./dates";
+export * from "./currencies";
+export * from "./price";
+export * from "./token";

--- a/utils/token.ts
+++ b/utils/token.ts
@@ -1,0 +1,2 @@
+export const shortenAddress = (address: string) =>
+  `${address.slice(0, 6)}...${address.slice(-4)}`;


### PR DESCRIPTION
This is only the UI for activity

Uses [Shadcn Table](https://ui.shadcn.com/docs/components/table) table component
Added 2 utils functions to help make things more readable:
- `formatDateTime`
- `shortenAddress`

few comments:
- data is mocked
- will not attempt to show avatar based on address at this time.
- Detect AI will come later
- pagination will come later

<img width="613" alt="image" src="https://github.com/SwaprHQ/presagio/assets/5664434/a44b2321-d5f1-468e-a715-c717ebb82711">
