### PR TITLE
[PGIO-46][FIX] - Flip button not centered when flipped inputs

### DIFF
--- a/app/components/Swapbox.tsx
+++ b/app/components/Swapbox.tsx
@@ -210,7 +210,7 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
           selectedToken={currentState.inToken}
           tokenList={outcomeList}
         >
-          <div className="flex items-center justify-end space-x-1.5 text-sm">
+          <div className="flex min-h-8 items-center justify-end space-x-1.5 text-sm">
             <p className="text-text-low-em">
               Balance:
               {currentState.balance
@@ -220,7 +220,7 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
             {!!currentState.balance && (
               <Button
                 variant="ghost"
-                className="text-text-primary-main text-sm font-semibold"
+                className="text-sm font-semibold text-text-primary-main"
                 onClick={maxBalance}
               >
                 Use MAX


### PR DESCRIPTION
## Fixes: [SWUI-46](https://linear.app/swaprhq/issue/PGIO-46/flip-button-not-centered-when-flipped-inputs)

## Description
* Update the minimum height for the balance tile in the Swapbox component

## Visual Evidence
<img width="511" alt="Screenshot 2024-06-28 at 16 07 52" src="https://github.com/SwaprHQ/presagio/assets/21271189/9679c64b-316d-4aec-ab8e-c0e259e80800">
