### PR TITLE
[PGIO-53][FEAT] - Improve actions in the Market activity table

### DIFF
--- a/app/markets/ActivityTable.tsx
+++ b/app/markets/ActivityTable.tsx
@@ -19,6 +19,7 @@ import {
   shortenAddress,
 } from '@/utils';
 import { Button, Icon, Tag, TagColorSchemeProp } from '@swapr/ui';
+import { Outcome } from '@/entities';
 
 const TAG_COLOR_SCHEMES: { 0: TagColorSchemeProp; 1: TagColorSchemeProp } = {
   0: 'success',
@@ -75,9 +76,14 @@ export const ActivityTable = ({ id }: { id: string }) => {
           <TableBody className="text-base font-semibold">
             {activities?.map(activity => {
               const outcomes = activity.fpmm.outcomes;
-              const outcomeIndex: 0 | 1 = activity.outcomeIndex;
 
-              if (!outcomes || !outcomeIndex) return null;
+              const outcome = new Outcome(
+                activity.outcomeIndex,
+                outcomes?.[activity.outcomeIndex] ?? 'Option 1',
+                id
+              );
+
+              if (!outcomes || !outcome.index) return null;
 
               return (
                 <TableRow key={activity.transactionHash}>
@@ -94,10 +100,10 @@ export const ActivityTable = ({ id }: { id: string }) => {
                   <TableCell>
                     <Tag
                       size="xs"
-                      colorScheme={TAG_COLOR_SCHEMES[outcomeIndex]}
+                      colorScheme={TAG_COLOR_SCHEMES[outcome.index as 0 | 1]}
                       className="w-fit uppercase"
                     >
-                      {outcomes[outcomeIndex]}
+                      {outcome.symbol}
                     </Tag>
                   </TableCell>
                   <TableCell className="truncate text-text-high-em">

--- a/app/markets/ActivityTable.tsx
+++ b/app/markets/ActivityTable.tsx
@@ -11,13 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/app/components/ui/Table';
-import {
-  FixedProductMarketMaker,
-  FpmmTrade_OrderBy,
-  OrderDirection,
-  Scalars,
-  getMarketTrades,
-} from '@/queries/omen';
+import { FpmmTrade_OrderBy, OrderDirection, getMarketTrades } from '@/queries/omen';
 import {
   formatDateTime,
   formatEtherWithFixedDecimals,
@@ -26,13 +20,9 @@ import {
 } from '@/utils';
 import { Button, Icon, Tag, TagColorSchemeProp } from '@swapr/ui';
 
-const getTagColorScheme = (
-  outcome: Scalars['String']['output'],
-  outcomes: NonNullable<FixedProductMarketMaker['outcomes']>
-): TagColorSchemeProp => {
-  if (outcome === outcomes[0]) return 'success';
-  else if (outcome === outcomes[1]) return 'danger';
-  else return 'info';
+const TAG_COLOR_SCHEMES: { 0: TagColorSchemeProp; 1: TagColorSchemeProp } = {
+  0: 'success',
+  1: 'danger',
 };
 
 const ITEMS_PER_PAGE = 10;
@@ -85,7 +75,7 @@ export const ActivityTable = ({ id }: { id: string }) => {
           <TableBody className="text-base font-semibold">
             {activities?.map(activity => {
               const outcomes = activity.fpmm.outcomes;
-              const outcomeIndex = activity.outcomeIndex;
+              const outcomeIndex: 0 | 1 = activity.outcomeIndex;
 
               if (!outcomes || !outcomeIndex) return null;
 
@@ -104,7 +94,7 @@ export const ActivityTable = ({ id }: { id: string }) => {
                   <TableCell>
                     <Tag
                       size="xs"
-                      colorScheme={getTagColorScheme(outcomes[outcomeIndex], outcomes)}
+                      colorScheme={TAG_COLOR_SCHEMES[outcomeIndex]}
                       className="w-fit uppercase"
                     >
                       {outcomes[outcomeIndex]}

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -283,6 +283,7 @@ const getMarketTradesQuery = gql`
       id
       outcomeIndex
       outcomeTokensTraded
+      transactionHash
       fpmm {
         outcomes
       }

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -250,6 +250,7 @@ const getMarketTransactionsQuery = gql`
       }
       fpmm {
         collateralToken
+        outcomes
         __typename
       }
       fpmmType
@@ -268,16 +269,20 @@ const getMarketTradesQuery = gql`
   query GetMarketUserTrades(
     $first: Int!
     $fpmm: ID!
+    $skip: Int
     $orderBy: String
     $orderDirection: String
   ) {
     fpmmTrades(
       first: $first
       orderBy: $orderBy
+      skip: $skip
       orderDirection: $orderDirection
       where: { fpmm: $fpmm }
     ) {
       creationTimestamp
+      id
+      outcomeIndex
     }
   }
 `;

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -283,6 +283,13 @@ const getMarketTradesQuery = gql`
       creationTimestamp
       id
       outcomeIndex
+      outcomeTokensTraded
+      fpmm {
+        outcomes
+      }
+      creator {
+        id
+      }
     }
   }
 `;

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -250,7 +250,6 @@ const getMarketTransactionsQuery = gql`
       }
       fpmm {
         collateralToken
-        outcomes
         __typename
       }
       fpmmType

--- a/queries/omen/types.ts
+++ b/queries/omen/types.ts
@@ -2339,7 +2339,6 @@ export type FpmmTransaction = {
   __typename?: 'FpmmTransaction';
   additionalSharesCost?: Maybe<Scalars['BigInt']['output']>;
   collateralTokenAmount: Scalars['BigInt']['output'];
-  outcomes?: Maybe<Array<Scalars['String']['output']>>;
   creationTimestamp: Scalars['BigInt']['output'];
   fpmm: FixedProductMarketMaker;
   fpmmType: FpmmType;

--- a/queries/omen/types.ts
+++ b/queries/omen/types.ts
@@ -2339,6 +2339,7 @@ export type FpmmTransaction = {
   __typename?: 'FpmmTransaction';
   additionalSharesCost?: Maybe<Scalars['BigInt']['output']>;
   collateralTokenAmount: Scalars['BigInt']['output'];
+  outcomes?: Maybe<Array<Scalars['String']['output']>>;
   creationTimestamp: Scalars['BigInt']['output'];
   fpmm: FixedProductMarketMaker;
   fpmmType: FpmmType;


### PR DESCRIPTION
## Fixes: [PGIO-53](https://linear.app/swaprhq/issue/PGIO-53/improve-activity-table)

## Description
* Updates the market `ActivityTable` component to display the traded outcome as an activity action instead displaying the transaction type.

## Visual Evidence
<img width="499" alt="Screenshot 2024-07-10 at 12 08 20" src="https://github.com/SwaprHQ/presagio/assets/21271189/6873641d-71c5-424f-a1d3-dda08fb57c39">


