### PR TITLE
fix: page should be reset to 1 when category is changed

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -146,6 +146,7 @@ export default function HomePage() {
 
   const handleCategory = (category: CategoryOptions) => {
     setCategory(category);
+    setPage(1);
 
     searchParams.delete('p');
     category ? searchParams.set('c', category) : searchParams.delete('c');


### PR DESCRIPTION
Currently it keeps the page, so if you are on the third page of the "all" you change to crypto and it queries for third page which is empty.

Whenever a category is changed it page should be reset it.

eg:
<img width="1918" alt="image" src="https://github.com/user-attachments/assets/be510107-7e98-4455-a383-47daa95989a0">


Issue: https://linear.app/swaprhq/issue/PGIO-78/changing-category-on-a-tab-should-reset-page-to-1