### PR TITLE
Fix closing soon search

### DIFF
--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -37,12 +37,15 @@ export const orderFilters: OrderFilter[] = [
     orderBy: FixedProductMarketMaker_OrderBy.UsdVolume,
     orderDirection: OrderDirection.Asc,
   },
+  {
+    name: 'Closing soon',
+    key: 'closing',
+    orderBy: FixedProductMarketMaker_OrderBy.OpeningTimestamp,
+    orderDirection: OrderDirection.Asc,
+  },
 ];
 
 const nowTimestamp = Math.floor(Date.now() / 1000);
-const in24HoursTimestamp = Math.floor(
-  new Date().setHours(new Date().getHours() + 24) / 1000
-);
 
 export type StateFilter = {
   name: string;
@@ -56,14 +59,7 @@ export const stateFilters: StateFilter[] = [
     key: 'open',
     when: {
       openingTimestamp_gt: nowTimestamp,
-    },
-  },
-  {
-    name: 'Closing soon',
-    key: 'closing',
-    when: {
-      openingTimestamp_lte: in24HoursTimestamp,
-      openingTimestamp_gt: nowTimestamp,
+      scaledLiquidityParameter_gt: 0,
     },
   },
   {

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -157,7 +157,7 @@ const getMarketsQuery = (
         ${params.openingTimestamp_gt ? 'openingTimestamp_gt: $openingTimestamp_gt' : ''}
         ${params.openingTimestamp_lt ? 'openingTimestamp_lt: $openingTimestamp_lt' : ''}
         ${params.isPendingArbitration !== undefined ? 'isPendingArbitration: $isPendingArbitration' : ''}
-        ${params.currentAnswer ? 'currentAnswer: $currentAnswer' : ''}
+        ${params.currentAnswer !== undefined ? 'currentAnswer: $currentAnswer' : ''}
         ${params.answerFinalizedTimestamp_lt ? 'answerFinalizedTimestamp_lt: $answerFinalizedTimestamp_lt' : ''}
         ${params.openingTimestamp_lte ? 'openingTimestamp_lte: $openingTimestamp_lte' : ''}
         ${params.scaledLiquidityParameter_gt !== undefined ? 'scaledLiquidityParameter_gt: $scaledLiquidityParameter_gt' : ''}

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -142,6 +142,7 @@ const getMarketsQuery = (
     $currentAnswer: Bytes
     $answerFinalizedTimestamp_lt: Int
     $openingTimestamp_lte: Int
+    $scaledLiquidityParameter_gt: Int
   ) {
     fixedProductMarketMakers(
       first: $first
@@ -155,10 +156,11 @@ const getMarketsQuery = (
         ${params.category_contains ? 'category_contains: $category_contains' : ''}
         ${params.openingTimestamp_gt ? 'openingTimestamp_gt: $openingTimestamp_gt' : ''}
         ${params.openingTimestamp_lt ? 'openingTimestamp_lt: $openingTimestamp_lt' : ''}
-        ${params.isPendingArbitration ? 'isPendingArbitration: $isPendingArbitration' : ''}
+        ${params.isPendingArbitration !== undefined ? 'isPendingArbitration: $isPendingArbitration' : ''}
         ${params.currentAnswer ? 'currentAnswer: $currentAnswer' : ''}
         ${params.answerFinalizedTimestamp_lt ? 'answerFinalizedTimestamp_lt: $answerFinalizedTimestamp_lt' : ''}
         ${params.openingTimestamp_lte ? 'openingTimestamp_lte: $openingTimestamp_lte' : ''}
+        ${params.scaledLiquidityParameter_gt !== undefined ? 'scaledLiquidityParameter_gt: $scaledLiquidityParameter_gt' : ''}
       }
     ) {
       ...marketData


### PR DESCRIPTION
Hey, small fix, please.

Currently, `Closing soon` is done as a filter for opening time <24 hours from now. The issue there is that:

1. These markets have usually withdrawn liquidity, which makes them as good as closed for the user of Presagio.
2. There is no guarantee that there will be any markets closing in less than X hours + having liquidity.

In PMAT library, we solve this by doing `Closing soon` by ordering them by `openingTimestamp ASC` + filtering for `openingTimestamp_gt>now` and `liquidity>0`. 

That's what I propose in this PR:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/0a3c117f-c6b7-4e4a-b79a-95ee1d434a86)
