### PR TITLE
Improve redeemed related logic

### DIFF
--- a/app/components/CardBet.tsx
+++ b/app/components/CardBet.tsx
@@ -52,7 +52,7 @@ export const CardBet = ({ userPositionComplete }: BetProps) => {
   const position = new Position(userPositionComplete.position);
   const outcomeIndex = position.getOutcomeIndex();
   const condition = position.condition;
-  const marketCondition = new MarketCondition(market, condition);
+  const marketCondition = new MarketCondition(userPositionComplete.fpmm, condition);
 
   const isWinner = market.isWinner(outcomeIndex);
   const isLoser = market.isLoser(outcomeIndex);

--- a/app/components/CardBet.tsx
+++ b/app/components/CardBet.tsx
@@ -10,6 +10,7 @@ import { Card, TokenLogo } from '@/app/components';
 import { formatDateTimeWithYear, remainingTime } from '@/utils/dates';
 import {
   Market,
+  MarketCondition,
   Position,
   tradesCollateralAmountUSDSpent,
   tradesOutcomeBalance,
@@ -28,15 +29,10 @@ interface BetProps {
 }
 
 export const CardBet = ({ userPositionComplete }: BetProps) => {
-  const position = new Position(userPositionComplete.position);
-  const outcomeIndex = position.outcomeIndex - 1;
-
-  const config = useConfig();
   const [txHash, setTxHash] = useState('');
   const [isTxLoading, setIsTxLoading] = useState(false);
   const { openModal } = useModal();
-
-  const market = new Market(userPositionComplete.market);
+  const config = useConfig();
 
   const collateralAmountUSDSpent = tradesCollateralAmountUSDSpent({
     fpmmTrades: userPositionComplete?.fpmmTrades,
@@ -49,24 +45,24 @@ export const CardBet = ({ userPositionComplete }: BetProps) => {
     fpmmTrades: userPositionComplete?.fpmmTrades,
   });
 
-  if (!market) return;
+  const market = new Market(userPositionComplete.fpmm);
+
+  if (!market) return null;
+
+  const position = new Position(userPositionComplete.position);
+  const outcomeIndex = position.getOutcomeIndex();
+  const condition = position.condition;
+  const marketCondition = new MarketCondition(market, condition);
 
   const isWinner = market.isWinner(outcomeIndex);
   const isLoser = market.isLoser(outcomeIndex);
+  const canRedeem = marketCondition.canRedeem(outcomeIndex, userPositionComplete.balance);
 
   const outcomeAmountString = market.isClosed
     ? isWinner
       ? 'You won'
       : 'You lost'
     : 'Potential win';
-
-  const condition = userPositionComplete.position.conditions[0];
-
-  const isClaimed = !outcomeBalance;
-  const isResolved = condition.resolved;
-  const hasPayoutDenominator = +condition.payoutDenominator > 0;
-
-  const canClaim = isWinner && isResolved && !isClaimed && hasPayoutDenominator;
 
   const redeem = async () => {
     setIsTxLoading(true);
@@ -97,12 +93,12 @@ export const CardBet = ({ userPositionComplete }: BetProps) => {
         isLoser && 'from-[#F2f2F2] to-[#f4cbc4] dark:from-[#131313] dark:to-[#301111]'
       )}
     >
-      <Link key={market.data.id} href={`markets?id=${market.data.id}`} className="block">
+      <Link key={market.fpmm.id} href={`markets?id=${market.fpmm.id}`} className="block">
         <section className="flex h-[144px] flex-col justify-between space-y-4 p-4">
           <div className="flex items-center justify-between">
             <div className="flex space-x-2">
               <Tag colorScheme="quaternary" size="sm" className="capitalize">
-                {market.data.category}
+                {market.fpmm.category}
               </Tag>
               <Tag colorScheme="success" size="sm">
                 You chose {position.getOutcome()}
@@ -117,10 +113,10 @@ export const CardBet = ({ userPositionComplete }: BetProps) => {
               width={40}
               height={40}
               className="size-[40px] rounded-8"
-              marketId={market.data.id}
+              marketId={market.fpmm.id}
             />
             <div className="text-normal h-[80px] flex-1 overflow-y-auto font-semibold text-text-high-em md:text-xl">
-              {market.data.title}
+              {market.fpmm.title}
             </div>
           </div>
         </section>
@@ -142,7 +138,7 @@ export const CardBet = ({ userPositionComplete }: BetProps) => {
                 {!market.isClosed || isWinner ? (
                   <>
                     <p>{formatValueWithFixedDecimals(outcomeBalance)}</p>
-                    <TokenLogo address={market.data.collateralToken} className="size-3" />
+                    <TokenLogo address={market.fpmm.collateralToken} className="size-3" />
                   </>
                 ) : (
                   '$' + formatValueWithFixedDecimals(collateralAmountUSDSpent)
@@ -158,7 +154,7 @@ export const CardBet = ({ userPositionComplete }: BetProps) => {
               </div>
             )}
           </div>
-          {canClaim && (
+          {canRedeem && (
             <>
               <Button size="sm" colorScheme="success" variant="pastel" onClick={redeem}>
                 Reedem

--- a/app/components/Swapbox.tsx
+++ b/app/components/Swapbox.tsx
@@ -52,10 +52,21 @@ export type SwapState = {
   refetchAllowence: () => void;
 };
 
-export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
-  const id = market.id as Address;
-  const outcome0 = new Outcome(0, market.outcomes?.[0] || 'Option 1', id);
-  const outcome1 = new Outcome(1, market.outcomes?.[1] || 'Option 2', id);
+interface SwapboxProps {
+  fixedProductMarketMaker: FixedProductMarketMaker;
+}
+export const Swapbox = ({ fixedProductMarketMaker }: SwapboxProps) => {
+  const id = fixedProductMarketMaker.id as Address;
+  const outcome0 = new Outcome(
+    0,
+    fixedProductMarketMaker.outcomes?.[0] || 'Option 1',
+    id
+  );
+  const outcome1 = new Outcome(
+    1,
+    fixedProductMarketMaker.outcomes?.[1] || 'Option 2',
+    id
+  );
 
   const { address, isDisconnected, chainId: connectorChainId } = useAccount();
   const supportedChains = useChains();
@@ -83,7 +94,7 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
 
   const { data: allowance, refetch: refetchCollateralAllowence } = useReadAllowance({
     address,
-    tokenAddress: market.collateralToken,
+    tokenAddress: fixedProductMarketMaker.collateralToken,
     spenderAddress: id,
   });
 
@@ -98,25 +109,25 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
 
   const { data: balance, refetch: refetchCollateralBalance } = useReadBalanceOf({
     address,
-    tokenAddress: market.collateralToken,
+    tokenAddress: fixedProductMarketMaker.collateralToken,
   });
 
   const { data: outcome0Balance, refetch: refetchOutcome0Balance } = useReadBalance(
     address,
-    market.collateralToken,
-    market.condition?.id,
+    fixedProductMarketMaker.collateralToken,
+    fixedProductMarketMaker.condition?.id,
     1
   );
 
   const { data: outcome1Balance, refetch: refetchOutcome1Balance } = useReadBalance(
     address,
-    market.collateralToken,
-    market.condition?.id,
+    fixedProductMarketMaker.collateralToken,
+    fixedProductMarketMaker.condition?.id,
     2
   );
 
   const { name, symbol, decimals } = useReadToken({
-    tokenAddress: market.collateralToken,
+    tokenAddress: fixedProductMarketMaker.collateralToken,
   });
 
   useEffect(() => {
@@ -127,13 +138,13 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
 
       setTokenAmountOut(amountOut);
     } else {
-      if (!market.outcomeTokenAmounts || !tokenAmountIn) return;
+      if (!fixedProductMarketMaker.outcomeTokenAmounts || !tokenAmountIn) return;
 
       const sellAmountInColleteral = calcSellAmountInCollateral(
         parseEther(tokenAmountIn).toString(),
-        market.outcomeTokenAmounts,
+        fixedProductMarketMaker.outcomeTokenAmounts,
         outcome.index,
-        parseFloat(formatEther(market.fee))
+        parseFloat(formatEther(fixedProductMarketMaker.fee))
       );
 
       if (!sellAmountInColleteral) return;
@@ -142,8 +153,8 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
     }
   }, [
     buyAmount,
-    market.fee,
-    market.outcomeTokenAmounts,
+    fixedProductMarketMaker.fee,
+    fixedProductMarketMaker.outcomeTokenAmounts,
     outcome.index,
     swapDirection,
     tokenAmountIn,
@@ -157,9 +168,9 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
 
   const oneShareSellPrice = calcSellAmountInCollateral(
     parseEther(ONE_UNIT).toString(),
-    market.outcomeTokenAmounts,
+    fixedProductMarketMaker.outcomeTokenAmounts,
     outcome.index,
-    parseFloat(formatEther(market.fee))
+    parseFloat(formatEther(fixedProductMarketMaker.fee))
   );
 
   const outcomeBalances = [outcome0Balance, outcome1Balance];
@@ -168,7 +179,7 @@ export const Swapbox = ({ market }: { market: FixedProductMarketMaker }) => {
 
   const collateralToken = new Token(
     ChainId.GNOSIS,
-    market.collateralToken,
+    fixedProductMarketMaker.collateralToken,
     decimals,
     symbol,
     name

--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -160,7 +160,7 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
 
           const isWinner = marketModel.isWinner(index);
 
-          const marketCondition = new MarketCondition(marketModel, condition);
+          const marketCondition = new MarketCondition(fixedProductMarketMaker, condition);
           const canClaim = marketCondition.canClaim(index);
           const alreadyClaimed = marketCondition.alreadyClaimed(
             index,

--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -26,16 +26,16 @@ import { TokenLogo } from '.';
 import { formatValueWithFixedDecimals } from '@/utils';
 
 interface UserBets {
-  market: FixedProductMarketMaker;
+  fixedProductMarketMaker: FixedProductMarketMaker;
 }
 
-export const UserBets = ({ market }: UserBets) => {
+export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
   const [txHash, setTxHash] = useState('');
   const [isTxLoading, setIsTxLoading] = useState(false);
   const { address } = useAccount();
   const { openModal } = useModal();
 
-  const conditionId = market.condition?.id;
+  const conditionId = fixedProductMarketMaker.condition?.id;
   const { data: conditionData, isLoading: isConditionLoading } = useQuery({
     queryKey: ['getCondition', conditionId],
     queryFn: async () => {
@@ -48,12 +48,12 @@ export const UserBets = ({ market }: UserBets) => {
   });
 
   const { data: userTrades, isLoading: isUserTradesLoading } = useQuery({
-    queryKey: ['getMarketUserTrades', address, market.id, ['0', '1']],
+    queryKey: ['getMarketUserTrades', address, fixedProductMarketMaker.id, ['0', '1']],
     queryFn: async () => {
       if (!!address)
         return getMarketUserTrades({
           creator: address.toLowerCase(),
-          fpmm: market.id,
+          fpmm: fixedProductMarketMaker.id,
           outcomeIndex_in: ['0', '1'],
         });
     },
@@ -81,22 +81,22 @@ export const UserBets = ({ market }: UserBets) => {
 
   const { data: outcome0Balance, isLoading: isOutcome0BalanceLoading } = useReadBalance(
     address,
-    market.collateralToken,
-    market.condition?.id,
+    fixedProductMarketMaker.collateralToken,
+    fixedProductMarketMaker.condition?.id,
     1
   );
 
   const { data: outcome1Balance, isLoading: isOutcome1BalanceLoading } = useReadBalance(
     address,
-    market.collateralToken,
-    market.condition?.id,
+    fixedProductMarketMaker.collateralToken,
+    fixedProductMarketMaker.condition?.id,
     2
   );
 
   const outcomesBalance = [outcome0Balance as bigint, outcome1Balance as bigint];
 
   const { name, symbol, decimals } = useReadToken({
-    tokenAddress: market.collateralToken,
+    tokenAddress: fixedProductMarketMaker.collateralToken,
   });
 
   if (
@@ -114,13 +114,13 @@ export const UserBets = ({ market }: UserBets) => {
 
   const collateralToken = new Token(
     ChainId.GNOSIS,
-    market.collateralToken,
+    fixedProductMarketMaker.collateralToken,
     decimals,
     symbol,
     name
   );
 
-  const marketModel = new Market(market);
+  const marketModel = new Market(fixedProductMarketMaker);
 
   const { condition } = conditionData;
   const isResolved = condition.resolved;

--- a/app/markets/ActivityChart.tsx
+++ b/app/markets/ActivityChart.tsx
@@ -40,7 +40,7 @@ export const ActivityChart = ({ id }: ActivityChartProps) => {
   >({
     queryKey: ['getMarket', id],
   });
-  const market = marketData?.fixedProductMarketMaker;
+  const fixedProductMarketMaker = marketData?.fixedProductMarketMaker;
 
   const { data: trades } = useQuery({
     queryKey: ['getMarketTrades', id],
@@ -107,7 +107,7 @@ export const ActivityChart = ({ id }: ActivityChartProps) => {
   if (isFetching || isFetchingMarket)
     return <div className="h-full w-full animate-pulse rounded-8 bg-outline-low-em" />;
 
-  if (!data || !market)
+  if (!data || !fixedProductMarketMaker)
     return (
       <p className="flex h-full items-center justify-center text-md">
         No available data.
@@ -154,7 +154,7 @@ export const ActivityChart = ({ id }: ActivityChartProps) => {
   const lastDataPoint = data[data.length - 1];
   const total = +lastDataPoint[OUTCOME_0] + +lastDataPoint[OUTCOME_1];
 
-  const marketModel = new Market(market);
+  const marketModel = new Market(fixedProductMarketMaker);
   const isLightTheme = resolvedTheme === 'light';
 
   return (

--- a/app/markets/Bet.tsx
+++ b/app/markets/Bet.tsx
@@ -6,21 +6,29 @@ import { FixedProductMarketMaker } from '@/queries/omen';
 import { Swapbox } from '@/app/components';
 import { KLEROS_URL, REALITY_QUESTION_URL } from '@/constants';
 
-export const Bet = ({ market }: { market: FixedProductMarketMaker }) => {
-  const marketModel = new Market(market);
+interface BetProps {
+  fixedProductMarketMaker: FixedProductMarketMaker;
+}
+
+export const Bet = ({ fixedProductMarketMaker }: BetProps) => {
+  const marketModel = new Market(fixedProductMarketMaker);
 
   if (!marketModel.isClosed && marketModel.hasLiquidity)
-    return <Swapbox market={market} />;
+    return <Swapbox fixedProductMarketMaker={fixedProductMarketMaker} />;
 
-  if (!market.isPendingArbitration && marketModel.answer === null && marketModel.isClosed)
+  if (
+    !fixedProductMarketMaker.isPendingArbitration &&
+    marketModel.answer === null &&
+    marketModel.isClosed
+  )
     return (
       <div className="flex flex-col items-center space-y-6 p-8">
         <p className="text-md">
           Answer still <span className="font-semibold">pending</span>.
         </p>
-        {market.question && (
+        {fixedProductMarketMaker.question && (
           <ButtonLink
-            href={`${REALITY_QUESTION_URL}${market.question.id}`}
+            href={`${REALITY_QUESTION_URL}${fixedProductMarketMaker.question.id}`}
             target="_blank"
             width="fit"
             className="flex items-center space-x-1"
@@ -33,7 +41,7 @@ export const Bet = ({ market }: { market: FixedProductMarketMaker }) => {
       </div>
     );
 
-  if (market.isPendingArbitration)
+  if (fixedProductMarketMaker.isPendingArbitration)
     return (
       <div className="flex flex-col items-center space-y-6 p-8">
         <p className="text-md">

--- a/app/markets/Info.tsx
+++ b/app/markets/Info.tsx
@@ -4,9 +4,12 @@ import { Icon, IconButton } from '@swapr/ui';
 import { FixedProductMarketMaker } from '../../queries/omen';
 import { GNOSIS_SCAN_URL, KLEROS_URL, REALITY_QUESTION_URL } from '@/constants';
 
-export const Info = ({ market }: { market: FixedProductMarketMaker }) => {
+interface InfoProps {
+  fixedProductMarketMaker: FixedProductMarketMaker;
+}
+export const Info = ({ fixedProductMarketMaker }: InfoProps) => {
   const [clipboardIcon, setClipboardIcon] = useState<'copy' | 'tick'>('copy');
-  const id = market.id;
+  const id = fixedProductMarketMaker.id;
 
   return (
     <>
@@ -34,9 +37,9 @@ export const Info = ({ market }: { market: FixedProductMarketMaker }) => {
         <span>View market contract</span>
         <Icon name="arrow-top-right" size={16} />
       </a>
-      {market.question && (
+      {fixedProductMarketMaker.question && (
         <a
-          href={`${REALITY_QUESTION_URL}${market.question.id}`}
+          href={`${REALITY_QUESTION_URL}${fixedProductMarketMaker.question.id}`}
           target="_blank"
           className="flex items-center space-x-1 py-4"
         >

--- a/app/markets/MarketDetails.tsx
+++ b/app/markets/MarketDetails.tsx
@@ -35,9 +35,9 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
   if (error) throw error;
   if (isLoading || !data?.fixedProductMarketMaker) return <LoadingMarketDetails />;
 
-  const marketOmenFpmm = data.fixedProductMarketMaker;
-  const marketModel = new Market(marketOmenFpmm);
-  const closingDate = new Date(+marketOmenFpmm.openingTimestamp * 1000);
+  const fixedProductMarketMaker = data.fixedProductMarketMaker;
+  const marketModel = new Market(fixedProductMarketMaker);
+  const closingDate = new Date(+fixedProductMarketMaker.openingTimestamp * 1000);
 
   return (
     <div className="w-full">
@@ -47,7 +47,7 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           <div className="space-y-4 p-5">
             <div className="flex items-center justify-between">
               <Tag className="w-fit capitalize" size="sm" colorScheme="quaternary">
-                {marketOmenFpmm.category}
+                {fixedProductMarketMaker.category}
               </Tag>
               {marketModel.isClosed ? (
                 <Tag className="w-fit capitalize" size="sm" colorScheme="quaternary">
@@ -62,12 +62,12 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
                 width={20}
                 height={20}
                 className="size-20 flex-shrink-0 rounded-8"
-                marketId={marketOmenFpmm.id}
+                marketId={fixedProductMarketMaker.id}
               />
-              <h1 className="text-xl font-semibold">{marketOmenFpmm.title}</h1>
+              <h1 className="text-xl font-semibold">{fixedProductMarketMaker.title}</h1>
             </div>
             <div className="!mt-7">
-              <OutcomeBar market={marketOmenFpmm} />
+              <OutcomeBar market={fixedProductMarketMaker} />
             </div>
           </div>
           <div className="px-4 pb-2">
@@ -91,7 +91,7 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           </div>
           {tab === Tabs.BET && (
             <div className="p-2">
-              <Bet market={marketOmenFpmm} />
+              <Bet fixedProductMarketMaker={fixedProductMarketMaker} />
             </div>
           )}
           {tab === Tabs.HISTORY && <HistorySection id={id} />}
@@ -102,11 +102,11 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           )}
           {tab === Tabs.INFO && (
             <div className="mx-4 my-2 flex flex-col divide-y divide-outline-low-em">
-              <Info market={marketOmenFpmm} />
+              <Info fixedProductMarketMaker={fixedProductMarketMaker} />
             </div>
           )}
         </div>
-        <UserBets market={marketOmenFpmm} />
+        <UserBets fixedProductMarketMaker={fixedProductMarketMaker} />
       </div>
     </div>
   );

--- a/app/markets/MarketDetails.tsx
+++ b/app/markets/MarketDetails.tsx
@@ -35,9 +35,9 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
   if (error) throw error;
   if (isLoading || !data?.fixedProductMarketMaker) return <LoadingMarketDetails />;
 
-  const market = data.fixedProductMarketMaker;
-  const marketModel = new Market(market);
-  const closingDate = new Date(+market.openingTimestamp * 1000);
+  const marketOmenFpmm = data.fixedProductMarketMaker;
+  const marketModel = new Market(marketOmenFpmm);
+  const closingDate = new Date(+marketOmenFpmm.openingTimestamp * 1000);
 
   return (
     <div className="w-full">
@@ -47,7 +47,7 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           <div className="space-y-4 p-5">
             <div className="flex items-center justify-between">
               <Tag className="w-fit capitalize" size="sm" colorScheme="quaternary">
-                {market.category}
+                {marketOmenFpmm.category}
               </Tag>
               {marketModel.isClosed ? (
                 <Tag className="w-fit capitalize" size="sm" colorScheme="quaternary">
@@ -62,12 +62,12 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
                 width={20}
                 height={20}
                 className="size-20 flex-shrink-0 rounded-8"
-                marketId={market.id}
+                marketId={marketOmenFpmm.id}
               />
-              <h1 className="text-xl font-semibold">{market.title}</h1>
+              <h1 className="text-xl font-semibold">{marketOmenFpmm.title}</h1>
             </div>
             <div className="!mt-7">
-              <OutcomeBar market={market} />
+              <OutcomeBar market={marketOmenFpmm} />
             </div>
           </div>
           <div className="px-4 pb-2">
@@ -91,7 +91,7 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           </div>
           {tab === Tabs.BET && (
             <div className="p-2">
-              <Bet market={market} />
+              <Bet market={marketOmenFpmm} />
             </div>
           )}
           {tab === Tabs.HISTORY && <HistorySection id={id} />}
@@ -102,11 +102,11 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
           )}
           {tab === Tabs.INFO && (
             <div className="mx-4 my-2 flex flex-col divide-y divide-outline-low-em">
-              <Info market={market} />
+              <Info market={marketOmenFpmm} />
             </div>
           )}
         </div>
-        <UserBets market={market} />
+        <UserBets market={marketOmenFpmm} />
       </div>
     </div>
   );

--- a/app/my-bets/page.tsx
+++ b/app/my-bets/page.tsx
@@ -109,10 +109,12 @@ export default function MyBetsPage() {
   const filterUnredeemedBets = useMemo(
     () =>
       userPositionsComplete?.filter(userPosition => {
-        const market = new Market(userPosition.fpmm);
         const position = new Position(userPosition.position);
         const outcomeIndex = position.getOutcomeIndex();
-        const marketCondition = new MarketCondition(market, position.condition);
+        const marketCondition = new MarketCondition(
+          userPosition.fpmm,
+          position.condition
+        );
         const canRedeem = marketCondition.canRedeem(outcomeIndex, userPosition.balance);
         return canRedeem;
       }) ?? [],

--- a/app/my-bets/page.tsx
+++ b/app/my-bets/page.tsx
@@ -3,7 +3,7 @@
 import { CardBet, LoadingCardBet } from '@/app/components/CardBet';
 import NoBetsPage from '@/app/my-bets/NoBetsPage';
 import NoWalletConnectedPage from '@/app/my-bets/NoWalletConnectedPage';
-import { Market, Position } from '@/entities';
+import { Market, MarketCondition, Position } from '@/entities';
 
 import { getUserPositions } from '@/queries/conditional-tokens';
 import { UserPosition, Condition } from '@/queries/conditional-tokens/types';
@@ -21,7 +21,7 @@ import { useAccount } from 'wagmi';
 
 export interface UserPositionComplete extends UserPosition {
   fpmmTrades: FpmmTrade[];
-  market: FixedProductMarketMaker;
+  fpmm: FixedProductMarketMaker;
   condition: Condition;
 }
 
@@ -60,13 +60,13 @@ export default function MyBetsPage() {
 
               const tradesData = await getMarketUserTrades({
                 creator: address.toLowerCase(),
-                fpmm: market.data.id,
+                fpmm: market.fpmm.id,
                 outcomeIndex_in: [outcomeIndex],
               });
 
               return {
                 ...userPosition,
-                market: market.data,
+                fpmm: market.fpmm,
                 condition: position.condition as Condition,
                 fpmmTrades: tradesData?.fpmmTrades || [],
               };
@@ -109,12 +109,11 @@ export default function MyBetsPage() {
   const filterUnredeemedBets = useMemo(
     () =>
       userPositionsComplete?.filter(userPosition => {
-        const marketModel = new Market(userPosition.market);
+        const market = new Market(userPosition.fpmm);
         const position = new Position(userPosition.position);
         const outcomeIndex = position.getOutcomeIndex();
-        const canClaim = marketModel.canClaim(outcomeIndex, position.condition);
-        const alreadyClaimed = canClaim && +userPosition.balance === 0;
-        const canRedeem = canClaim && !alreadyClaimed;
+        const marketCondition = new MarketCondition(market, position.condition);
+        const canRedeem = marketCondition.canRedeem(outcomeIndex, userPosition.balance);
         return canRedeem;
       }) ?? [],
     [userPositionsComplete]

--- a/entities/markets/index.ts
+++ b/entities/markets/index.ts
@@ -2,3 +2,4 @@ export * from './market';
 export * from './position';
 export * from './outcome';
 export * from './trade';
+export * from './marketCondition';

--- a/entities/markets/market.ts
+++ b/entities/markets/market.ts
@@ -2,37 +2,36 @@ import { FixedProductMarketMaker } from '@/queries/omen';
 import { fromHex } from 'viem';
 import { Outcome } from '@/entities';
 import { isPast } from 'date-fns';
-import { Condition } from '@/queries/conditional-tokens/types';
 
 export class Market {
-  data: FixedProductMarketMaker;
+  fpmm: FixedProductMarketMaker;
   closingDate: Date;
   answer: number | null;
   isClosed: boolean;
   outcomes: Outcome[];
   hasLiquidity: boolean;
 
-  constructor(market: FixedProductMarketMaker) {
-    this.data = market;
-    this.closingDate = new Date(+market.openingTimestamp * 1000);
-    this.answer = market?.question?.currentAnswer
-      ? fromHex(market.question.currentAnswer, 'number')
+  constructor(fpmm: FixedProductMarketMaker) {
+    this.fpmm = fpmm;
+    this.closingDate = new Date(+fpmm.openingTimestamp * 1000);
+    this.answer = fpmm?.question?.currentAnswer
+      ? fromHex(fpmm.question.currentAnswer, 'number')
       : null;
     this.isClosed = this.answer !== null || isPast(this.closingDate);
-    this.hasLiquidity = Number(market.scaledLiquidityParameter) > 0;
+    this.hasLiquidity = Number(fpmm.scaledLiquidityParameter) > 0;
 
     this.outcomes = [
       new Outcome(
         0,
-        market.outcomes?.[0] || 'Option 1',
-        market.id,
-        market.outcomeTokenMarginalPrices?.[0]
+        fpmm.outcomes?.[0] || 'Option 1',
+        fpmm.id,
+        fpmm.outcomeTokenMarginalPrices?.[0]
       ),
       new Outcome(
         1,
-        market.outcomes?.[1] || 'Option 2',
-        market.id,
-        market.outcomeTokenMarginalPrices?.[1]
+        fpmm.outcomes?.[1] || 'Option 2',
+        fpmm.id,
+        fpmm.outcomeTokenMarginalPrices?.[1]
       ),
     ];
   }
@@ -47,12 +46,5 @@ export class Market {
 
   getWinnerOutcome() {
     return this.isClosed && this.answer !== null ? this.outcomes[this.answer] : null;
-  }
-
-  canClaim(index: number, condition: Condition) {
-    const isResolved = condition.resolved;
-    const hasPayoutDenominator = +condition.payoutDenominator > 0;
-
-    return this.isWinner(index) && isResolved && hasPayoutDenominator;
   }
 }

--- a/entities/markets/marketCondition.ts
+++ b/entities/markets/marketCondition.ts
@@ -1,0 +1,30 @@
+import { Market } from '@/entities/markets/market';
+import { Condition as ConditionalTokenCondition } from '@/queries/conditional-tokens/types';
+
+export class MarketCondition {
+  market: Market;
+  condition: ConditionalTokenCondition;
+
+  constructor(market: Market, condition: ConditionalTokenCondition) {
+    this.market = market;
+    this.condition = condition;
+  }
+
+  canClaim(index: number) {
+    const isResolved = this.condition.resolved;
+    const hasPayoutDenominator = +this.condition.payoutDenominator > 0;
+
+    return this.market.isWinner(index) && isResolved && hasPayoutDenominator;
+  }
+
+  alreadyClaimed(index: number, outcomeBalance: BigInt | string) {
+    const zero = typeof outcomeBalance === 'bigint' ? BigInt(0) : 0;
+    const balance = typeof outcomeBalance === 'string' ? +outcomeBalance : outcomeBalance;
+
+    return this.canClaim(index) && balance === zero;
+  }
+
+  canRedeem(index: number, outcomeBalance: any) {
+    return this.canClaim(index) && !this.alreadyClaimed(index, outcomeBalance);
+  }
+}

--- a/entities/markets/marketCondition.ts
+++ b/entities/markets/marketCondition.ts
@@ -1,12 +1,12 @@
 import { Market } from '@/entities/markets/market';
 import { Condition as ConditionalTokenCondition } from '@/queries/conditional-tokens/types';
+import { FixedProductMarketMaker } from '@/queries/omen';
 
-export class MarketCondition {
-  market: Market;
+export class MarketCondition extends Market {
   condition: ConditionalTokenCondition;
 
-  constructor(market: Market, condition: ConditionalTokenCondition) {
-    this.market = market;
+  constructor(fpmm: FixedProductMarketMaker, condition: ConditionalTokenCondition) {
+    super(fpmm);
     this.condition = condition;
   }
 
@@ -14,7 +14,7 @@ export class MarketCondition {
     const isResolved = this.condition.resolved;
     const hasPayoutDenominator = +this.condition.payoutDenominator > 0;
 
-    return this.market.isWinner(index) && isResolved && hasPayoutDenominator;
+    return this.isWinner(index) && isResolved && hasPayoutDenominator;
   }
 
   alreadyClaimed(index: number, outcomeBalance: BigInt | string) {

--- a/entities/markets/trade.ts
+++ b/entities/markets/trade.ts
@@ -31,3 +31,8 @@ export const tradesCollateralAmountUSDSpent = ({ fpmmTrades }: tradesProps) => {
     }, 0) ?? 0
   );
 };
+
+export const getOutcomeUserTrades = ({ fpmmTrades }: tradesProps) => [
+  fpmmTrades?.filter(trade => trade.outcomeIndex === '0') || [],
+  fpmmTrades?.filter(trade => trade.outcomeIndex === '1') || [],
+];

--- a/queries/conditional-tokens/queries.ts
+++ b/queries/conditional-tokens/queries.ts
@@ -24,6 +24,7 @@ const getUserPositionsQuery = gql`
         lastActive
       }
       position {
+        id
         activeValue
         conditionIdsStr
         indexSets


### PR DESCRIPTION
- rename market to a more specific name: FixedProductMarketMaker
- fixes bug CardBet showing redeem button when already claimed
- on Market ententy rename market to fpmm
- add new entity MarketCondition to handle condition related like canRedeem, canClaim
 - remove those methods from market
- refactor UserBets to use tradesCollateralAmountUSDSpent
- extract getOutcomeUserTrades to Trade entity
- improves names
- add id to position on Omen Markets query