### PR TITLE
Add finalizing filter

### DIFF
--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -75,6 +75,7 @@ export const stateFilters: StateFilter[] = [
     when: {
       openingTimestamp_lt: nowTimestamp,
       isPendingArbitration: false,
+      currentAnswer_not: null,
     },
   },
   {

--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -70,6 +70,14 @@ export const stateFilters: StateFilter[] = [
     },
   },
   {
+    name: 'Finalizing',
+    key: 'finalizing',
+    when: {
+      openingTimestamp_lt: nowTimestamp,
+      isPendingArbitration: false,
+    },
+  },
+  {
     name: 'Pending',
     key: 'pending',
     when: {

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -140,6 +140,7 @@ const getMarketsQuery = (
     $openingTimestamp_lt: Int
     $isPendingArbitration: Boolean
     $currentAnswer: Bytes
+    $currentAnswer_not: Bytes
     $answerFinalizedTimestamp_lt: Int
     $openingTimestamp_lte: Int
     $scaledLiquidityParameter_gt: Int
@@ -158,6 +159,7 @@ const getMarketsQuery = (
         ${params.openingTimestamp_lt ? 'openingTimestamp_lt: $openingTimestamp_lt' : ''}
         ${params.isPendingArbitration !== undefined ? 'isPendingArbitration: $isPendingArbitration' : ''}
         ${params.currentAnswer !== undefined ? 'currentAnswer: $currentAnswer' : ''}
+        ${params.currentAnswer_not !== undefined ? 'currentAnswer_not: $currentAnswer_not' : ''}
         ${params.answerFinalizedTimestamp_lt ? 'answerFinalizedTimestamp_lt: $answerFinalizedTimestamp_lt' : ''}
         ${params.openingTimestamp_lte ? 'openingTimestamp_lte: $openingTimestamp_lte' : ''}
         ${params.scaledLiquidityParameter_gt !== undefined ? 'scaledLiquidityParameter_gt: $scaledLiquidityParameter_gt' : ''}


### PR DESCRIPTION
I'm currently working on a `challenger agent`, it's supposed to challenge questions on Reality, and I was missing this filter.

In the current version, there is no way to search for a market that is answered but not yet finalized.

The `Pending` filter is great, but that will show only markets without any answer on Reality.

Current dev:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/f68faee8-f293-46b8-803c-c773fc52b08a)

Local test:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/8c68ee34-088a-43b4-bcab-f9418912e516)

Reality:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/f524f5a5-83c7-4e0e-a3d4-b3d8eab37bfd)
