### PR TITLE
fix: pass outcomeIndex to redeem in userBets

### DIFF
--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -125,13 +125,13 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
   const { condition } = conditionData;
   const isResolved = condition.resolved;
 
-  const redeem = async () => {
+  const redeem = async (outcomeIndex: number) => {
     setIsTxLoading(true);
 
     try {
       const txHash = await redeemPositions({
         conditionId: condition.id,
-        outcomeIndex: 1,
+        outcomeIndex: outcomeIndex,
       });
       setTxHash(txHash);
       openModal(ModalId.WAITING_TRANSACTION);
@@ -243,7 +243,7 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
                         width="full"
                         size="lg"
                         className="space-x-2"
-                        onClick={redeem}
+                        onClick={redeem(index)}
                       >
                         <TokenLogo address={collateralToken.address} size="xs" />
                         <p>


### PR DESCRIPTION
fixes #97 

I'm not actually sure if this is the approach, I didn't know how to get the position, and I don't know if the indexes of the `marketModel` are the same as the `outcomeIndex`, feel free to ignore. wasn't able to test since I'm lacking API keys to fetch subgraph / dune info.

https://github.com/greenlucid/presagio/blob/e67fb2c69c3113b74f82e706b1d242d3ff571a94/app/components/UserBets.tsx#L57
leads me to think they might be different, since it's filtering for only those outcomeIndexes for some reason? unless, that filtering is also a bug. not too familiar with this codebase tbh