### PR TITLE
[PGIO-85][FEAT] - dynamically fetch categories from Dune

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,6 @@ type CategoryOptions = Categories | '';
 type DuneCategory = { Category: string };
 
 /**
- *
  * @param {DunateCategory[]} data - Response from Dune API query
  * @returns {{ [key in Categories]: number }[]} A sorted array of objects with the count of markets per category
  */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,10 +45,6 @@ const SEARCH_DEBOUNCE_DELAY = 600;
 type CategoryOptions = Categories | '';
 type DuneCategory = { Category: string };
 
-/**
- * @param {DunateCategory[]} data - Response from Dune API query
- * @returns {{ [key in Categories]: number }[]} A sorted array of objects with the count of markets per category
- */
 const rankCategoriesByMarketCount = (data: any) => {
   if (!data) return [];
 
@@ -274,37 +270,37 @@ export default function HomePage() {
 
   return (
     <div className="mt-12 justify-center space-y-8 px-6 md:flex md:flex-col md:items-center md:px-10 lg:px-20 xl:px-40">
-      {/* {openMarketsLoading ? (
+      {openMarketsLoading ? (
         <LoadingMarketCategories />
-      ) : ( */}
-      <div className="w-full">
-        <ToggleGroup
-          value={category}
-          onChange={handleCategory}
-          className="overflow-x-scroll md:overflow-x-auto"
-        >
-          <ToggleGroupOption size="md" value={''} className="font-semibold">
-            All
-          </ToggleGroupOption>
-          {marketCategories?.map(marketCategory => {
-            const categoryOption = openMarkets?.length
-              ? Object.keys(marketCategory)[0]
-              : marketCategory;
+      ) : (
+        <div className="w-full">
+          <ToggleGroup
+            value={category}
+            onChange={handleCategory}
+            className="overflow-x-scroll md:overflow-x-auto"
+          >
+            <ToggleGroupOption size="md" value={''} className="font-semibold">
+              All
+            </ToggleGroupOption>
+            {marketCategories?.map(marketCategory => {
+              const categoryOption = openMarkets?.length
+                ? Object.keys(marketCategory)[0]
+                : marketCategory;
 
-            return (
-              <ToggleGroupOption
-                key={categoryOption}
-                value={categoryOption}
-                className="font-semibold capitalize"
-                size="md"
-              >
-                {categoryOption}
-              </ToggleGroupOption>
-            );
-          })}
-        </ToggleGroup>
-      </div>
-      {/* )} */}
+              return (
+                <ToggleGroupOption
+                  key={categoryOption}
+                  value={categoryOption}
+                  className="font-semibold capitalize"
+                  size="md"
+                >
+                  {categoryOption}
+                </ToggleGroupOption>
+              );
+            })}
+          </ToggleGroup>
+        </div>
+      )}
       <div className="flex w-full flex-wrap items-center gap-2 sm:flex-nowrap">
         <Input
           className="w-full"
@@ -522,9 +518,9 @@ export default function HomePage() {
 
 const LoadingMarketCategories = () => (
   <div className="w-full">
-    <div className="flex w-auto space-x-1 rounded-12 bg-surface-surface-2 p-1 md:w-fit">
+    <div className="flex h-12 w-[796px] items-center justify-between space-x-1 rounded-12 bg-surface-surface-2 px-3 py-1">
       {Array.from({ length: DEFAULT_CATEGORIES.length + 1 }).map((_, index) => (
-        <Skeleton className="h-10 w-[85px]" key={index} />
+        <Skeleton className="h-6 w-[80px]" key={index} />
       ))}
     </div>
   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -274,37 +274,37 @@ export default function HomePage() {
 
   return (
     <div className="mt-12 justify-center space-y-8 px-6 md:flex md:flex-col md:items-center md:px-10 lg:px-20 xl:px-40">
-      {openMarketsLoading ? (
+      {/* {openMarketsLoading ? (
         <LoadingMarketCategories />
-      ) : (
-        <div className="w-full">
-          <ToggleGroup
-            value={category}
-            onChange={handleCategory}
-            className="overflow-x-scroll md:overflow-x-auto"
-          >
-            <ToggleGroupOption size="md" value={''} className="font-semibold">
-              All
-            </ToggleGroupOption>
-            {marketCategories?.map(marketCategory => {
-              const categoryOption = openMarkets?.length
-                ? Object.keys(marketCategory)[0]
-                : marketCategory;
+      ) : ( */}
+      <div className="w-full">
+        <ToggleGroup
+          value={category}
+          onChange={handleCategory}
+          className="overflow-x-scroll md:overflow-x-auto"
+        >
+          <ToggleGroupOption size="md" value={''} className="font-semibold">
+            All
+          </ToggleGroupOption>
+          {marketCategories?.map(marketCategory => {
+            const categoryOption = openMarkets?.length
+              ? Object.keys(marketCategory)[0]
+              : marketCategory;
 
-              return (
-                <ToggleGroupOption
-                  key={categoryOption}
-                  value={categoryOption}
-                  className="font-semibold capitalize"
-                  size="md"
-                >
-                  {categoryOption}
-                </ToggleGroupOption>
-              );
-            })}
-          </ToggleGroup>
-        </div>
-      )}
+            return (
+              <ToggleGroupOption
+                key={categoryOption}
+                value={categoryOption}
+                className="font-semibold capitalize"
+                size="md"
+              >
+                {categoryOption}
+              </ToggleGroupOption>
+            );
+          })}
+        </ToggleGroup>
+      </div>
+      {/* )} */}
       <div className="flex w-full flex-wrap items-center gap-2 sm:flex-nowrap">
         <Input
           className="w-full"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,21 +34,21 @@ import Image from 'next/image';
 import { getOpenMarkets } from '@/queries/dune';
 import { Categories } from '@/constants';
 
-const ITEMS_PER_PAGE = 12;
-const SEARCH_DEBOUNCE_DELAY = 600;
+const DEFAULT_CATEGORIES = Object.values(Categories);
+const DEFAULT_CREATOR_OPTION = creatorFilters[0];
 const DEFAULT_ORDER_OPTION = orderFilters[0];
 const DEFAULT_STATE_OPTION = stateFilters[0];
-const DEFAULT_CREATOR_OPTION = creatorFilters[0];
 const DEFAULT_TOKEN_OPTION = tokenFilters[0];
+const ITEMS_PER_PAGE = 12;
+const SEARCH_DEBOUNCE_DELAY = 600;
 
 type CategoryOptions = Categories | '';
 type DuneCategory = { Category: string };
-type PresagioCategory = { [key in Categories]: number };
 
 /**
  *
  * @param {DunateCategory[]} data - Response from Dune API query
- * @returns {PresagioCategory[]} A sorted array of objects with the count of markets per category
+ * @returns {{ [key in Categories]: number }[]} A sorted array of objects with the count of markets per category
  */
 const rankCategoriesByMarketCount = (data: any) => {
   if (!data) return [];
@@ -67,8 +67,6 @@ const rankCategoriesByMarketCount = (data: any) => {
 
   return countByCategory.sort((a, b) => Object.values(b)[0] - Object.values(a)[0]);
 };
-
-const DEFAULT_CATEGORIES = Object.values(Categories);
 
 export default function HomePage() {
   const router = useRouter();
@@ -130,13 +128,12 @@ export default function HomePage() {
       tokenFilters.find(option => option.key === filterValueFromSearchParams) ||
       DEFAULT_TOKEN_OPTION
     );
-  }
+  };
 
   const [selectedCreatorOption, setSelectedCreatorOption] =
     useState(initialCreatorFilter());
 
-  const [selectedTokenOption, setSelectedTokenOption] =
-    useState(initialTokenFilter());
+  const [selectedTokenOption, setSelectedTokenOption] = useState(initialTokenFilter());
 
   const initialPage = () => {
     const page = searchParams.get('p');
@@ -242,7 +239,7 @@ export default function HomePage() {
     searchParams.delete('p');
     searchParams.set('tf', option.key);
     router.replace(`?${searchParams.toString()}`);
-  }
+  };
 
   const handleNextPage = (page: number) => {
     if (page <= 0) return;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -57,3 +57,14 @@ export const GNOSIS_SCAN_URL = 'https://gnosisscan.io';
 export const KLEROS_URL = 'https://kleros.io';
 const REALITY_URL = 'https://reality.eth.limo';
 export const REALITY_QUESTION_URL = `${REALITY_URL}/app/#!/network/100/question/0x79e32ae03fb27b07c89c0c568f80287c01ca2e57-`;
+
+export enum Categories {
+  TECHNOLOGY = 'technology',
+  CRYPTO = 'crypto',
+  BUSINESS = 'business',
+  POLITICS = 'politics',
+  ECONOMY = 'economy',
+  INTERNATIONAL = 'international',
+  SPORTS = 'sports',
+  ENTERTAINMENT = 'entertainment',
+}

--- a/queries/dune/queries.ts
+++ b/queries/dune/queries.ts
@@ -1,5 +1,11 @@
-import { LatestResultArgs, ParameterType } from '@duneanalytics/client-sdk';
+import { LatestResultArgs, ParameterType, RunQueryArgs } from '@duneanalytics/client-sdk';
 import { duneClient } from '@/utils';
+import { Categories } from '@/constants';
+
+const DUNE_OPEN_MARKETS_INFO_QUERY_ID = 3781367;
+const DUNE_MARKET_CATEGORIES_INFO_QUERY_ID = 3582989;
+
+const presagioCategories = Object.values(Categories).join(',');
 
 export const getAIAgents = async () => {
   const DUNE_AGENTS_INFO_QUERY_ID = 3582994;
@@ -7,6 +13,32 @@ export const getAIAgents = async () => {
   const options: LatestResultArgs = {
     queryId: DUNE_AGENTS_INFO_QUERY_ID,
     parameters: [{ type: ParameterType.NUMBER, value: '1', name: 'limit' }],
+  };
+
+  const duneResult = await duneClient.getLatestResult(options);
+
+  return duneResult.result?.rows;
+};
+
+export const getOpenMarkets = async () => {
+  const options: RunQueryArgs = {
+    queryId: DUNE_OPEN_MARKETS_INFO_QUERY_ID,
+    filters: `category in (${presagioCategories})`,
+    columns: ['category'],
+    sort_by: 'category asc',
+  };
+
+  const duneResult = await duneClient.getLatestResult(options);
+
+  return duneResult.result?.rows;
+};
+
+export const getMarketCategories = async () => {
+  const options: RunQueryArgs = {
+    queryId: DUNE_MARKET_CATEGORIES_INFO_QUERY_ID,
+    filters: `category in (${presagioCategories})`,
+    columns: ['category', 'cnt'],
+    sort_by: 'cnt desc',
   };
 
   const duneResult = await duneClient.getLatestResult(options);

--- a/queries/dune/queries.ts
+++ b/queries/dune/queries.ts
@@ -3,7 +3,6 @@ import { duneClient } from '@/utils';
 import { Categories } from '@/constants';
 
 const DUNE_OPEN_MARKETS_INFO_QUERY_ID = 3781367;
-const DUNE_MARKET_CATEGORIES_INFO_QUERY_ID = 3582989;
 
 const presagioCategories = Object.values(Categories).join(',');
 
@@ -26,19 +25,6 @@ export const getOpenMarkets = async () => {
     filters: `category in (${presagioCategories})`,
     columns: ['category'],
     sort_by: 'category asc',
-  };
-
-  const duneResult = await duneClient.getLatestResult(options);
-
-  return duneResult.result?.rows;
-};
-
-export const getMarketCategories = async () => {
-  const options: RunQueryArgs = {
-    queryId: DUNE_MARKET_CATEGORIES_INFO_QUERY_ID,
-    filters: `category in (${presagioCategories})`,
-    columns: ['category', 'cnt'],
-    sort_by: 'cnt desc',
   };
 
   const duneResult = await duneClient.getLatestResult(options);


### PR DESCRIPTION
## Fixes: [PGIO-85](https://linear.app/swaprhq/issue/PGIO-85/order-categories)

## Description
* Creates a way to query Dune dashboards to fetch our market categories sorted by "popularity", meaning, the number of markets in each category.

## Visual Evidence
![Screenshot 2024-09-23 at 15 10 02](https://github.com/user-attachments/assets/68ca70d1-a4fb-4dd7-9a28-c5af35a03394)


