### PR TITLE
Update redeemPositions contract function with a fixed set of outcomeIndexOptions

### DIFF
--- a/app/components/CardBet.tsx
+++ b/app/components/CardBet.tsx
@@ -152,7 +152,6 @@ export const MyBetsCardBet = ({ userBets }: { userBets: UserBets }) => {
     try {
       const txHash = await redeemPositions({
         conditionId: condition.id,
-        outcomeIndex: position.outcomeIndex,
       });
       setTxHash(txHash);
       openModal(ModalId.WAITING_TRANSACTION);

--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -131,7 +131,6 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
     try {
       const txHash = await redeemPositions({
         conditionId: condition.id,
-        outcomeIndex: 1,
       });
       setTxHash(txHash);
       openModal(ModalId.WAITING_TRANSACTION);

--- a/hooks/contracts/conditionalTokens.ts
+++ b/hooks/contracts/conditionalTokens.ts
@@ -66,23 +66,28 @@ export const useReadBalance = (
   return useReadBalanceOf(owner, positionId as number);
 };
 
+// currently we only support 2 outcomes, so we can hardcode the indexSetOptions
+// on the contract level it will check both outcomes and withdraw the correct one
+type IndexSetOptions = [1, 2];
+const outcomeIndexOptions: IndexSetOptions = [1, 2];
+
 interface RedeemPositionsArgs {
   collateralToken?: string;
   parentCollectionId?: string;
   conditionId: string;
-  outcomeIndex: number;
+  outcomeIndex?: IndexSetOptions;
 }
 
 export const redeemPositions = async ({
   collateralToken = WXDAI.address,
   parentCollectionId = zeroHash,
   conditionId,
-  outcomeIndex,
+  outcomeIndex = outcomeIndexOptions,
 }: RedeemPositionsArgs) => {
   return await writeContract(config, {
     abi: ConditionalTokensABI,
     address: CONDITIONAL_TOKEN_CONTRACT_ADDRESS,
     functionName: 'redeemPositions',
-    args: [collateralToken, parentCollectionId, conditionId, [outcomeIndex]],
+    args: [collateralToken, parentCollectionId, conditionId, outcomeIndex],
   });
 };


### PR DESCRIPTION
**Description** 
As we currently only support 2 outcomes we can hardcode the indexSetOptions to [1,2] _(indexSet starts on 1 instead of 0, on Conditional Token contract)_ so we don't need to pass it on `redeemPositions` function. On the contract level it will check both outcomes and withdraw the correct one. We can think of a robust solution when we allow more options.

Closes #97
Closes #98 

Thanks @greenlucid for the issue report and PR.
 
**Summary** 
- adds indexSetOptions type
- adds default value to outcomeIndexOptions
- remove outcomeIndex argument on redeemPositions function

**How to test**
- try redeeming positions on "My bets" list
- try redeeming positions on a market

**screenshots**
meant to show where to test, those "redeem" buttons 
"My bets" list
<img width="945" alt="image" src="https://github.com/user-attachments/assets/4d99b62c-282c-4aee-a568-b9ba190af44c">
Market
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/6b63d359-2cb6-49be-a979-09c0e0965529">
