### PR TITLE
Fix: On redeem was triggering TransactionModal Success straight way without completing and loading

### DIFF
--- a/app/components/CardBet.tsx
+++ b/app/components/CardBet.tsx
@@ -141,12 +141,11 @@ export const MyBetsCardBet = ({ userBets }: { userBets: UserBets }) => {
   const canRedeem = marketCondition.canRedeem(outcomeIndex, userBets.balance);
 
   const redeem = async () => {
-    await submitCustomTx({
-      writeTxFunction: redeemPositions,
-      args: {
+    await submitCustomTx(() =>
+      redeemPositions({
         conditionId: condition.id,
-      },
-    });
+      })
+    );
   };
 
   return (

--- a/app/components/TransactionModal.tsx
+++ b/app/components/TransactionModal.tsx
@@ -57,7 +57,7 @@ export const TransactionModal = ({
               </>
             ) : (
               <>
-                {!isError && (
+                {txHash && !isError && (
                   <>
                     <IconBadge name="tick" colorScheme="success" />
                     <div className="flex flex-col items-center space-y-2">
@@ -88,8 +88,8 @@ export const TransactionModal = ({
             )}
           </div>
         </DialogBody>
-        <DialogFooter>
-          {txHash && (
+        {txHash && (
+          <DialogFooter>
             <a
               href={`https://gnosisscan.io/tx/${txHash}`}
               target="_blank"
@@ -107,8 +107,8 @@ export const TransactionModal = ({
                 </>
               </Button>
             </a>
-          )}
-        </DialogFooter>
+          </DialogFooter>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -3,7 +3,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useAccount } from 'wagmi';
 import { cx } from 'class-variance-authority';
-import { waitForTransactionReceipt } from 'wagmi/actions';
 import {
   getOutcomeUserTrades,
   Market,
@@ -12,28 +11,23 @@ import {
   tradesCollateralAmountUSDSpent,
   tradesOutcomeBalance,
 } from '@/entities';
-import { useState } from 'react';
 import { Button, Icon, Tag } from '@swapr/ui';
 import { ChainId } from '@/constants';
-import { TransactionModal } from '.';
-import { ModalId, useModal } from '@/context/ModalContext';
-import { config } from '@/providers/chain-config';
 import { redeemPositions, useReadBalance } from '@/hooks/contracts';
 import { getCondition } from '@/queries/conditional-tokens';
 import { FixedProductMarketMaker, getMarketUserTrades } from '@/queries/omen';
 import { useReadToken } from '@/hooks/contracts/erc20';
 import { TokenLogo } from '.';
 import { formatValueWithFixedDecimals } from '@/utils';
+import { useTx } from '@/context';
 
 interface UserBets {
   fixedProductMarketMaker: FixedProductMarketMaker;
 }
 
 export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
-  const [txHash, setTxHash] = useState('');
-  const [isTxLoading, setIsTxLoading] = useState(false);
   const { address } = useAccount();
-  const { openModal } = useModal();
+  const { submitCustomTx } = useTx();
 
   const conditionId = fixedProductMarketMaker.condition?.id;
   const { data: conditionData, isLoading: isConditionLoading } = useQuery({
@@ -126,23 +120,12 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
   const isResolved = condition.resolved;
 
   const redeem = async () => {
-    setIsTxLoading(true);
-
-    try {
-      const txHash = await redeemPositions({
+    await submitCustomTx({
+      writeTxFunction: redeemPositions,
+      args: {
         conditionId: condition.id,
-      });
-      setTxHash(txHash);
-      openModal(ModalId.WAITING_TRANSACTION);
-
-      await waitForTransactionReceipt(config, {
-        hash: txHash,
-      });
-    } catch (error) {
-      console.error(error);
-    } finally {
-      setIsTxLoading(false);
-    }
+      },
+    });
   };
 
   const hasBetted =
@@ -244,13 +227,16 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
                         className="space-x-2"
                         onClick={redeem}
                       >
-                        <TokenLogo address={collateralToken.address} size="xs" />
                         <p>
                           Redeem {tradedBalance} {collateralToken.symbol}
                         </p>
+                        <TokenLogo
+                          address={collateralToken.address}
+                          size="xs"
+                          className="size-4"
+                        />
                       </Button>
                     </div>
-                    <TransactionModal isLoading={isTxLoading} txHash={txHash} />
                   </>
                 )}
               </div>

--- a/app/components/UserBets.tsx
+++ b/app/components/UserBets.tsx
@@ -120,12 +120,11 @@ export const UserBets = ({ fixedProductMarketMaker }: UserBets) => {
   const isResolved = condition.resolved;
 
   const redeem = async () => {
-    await submitCustomTx({
-      writeTxFunction: redeemPositions,
-      args: {
+    await submitCustomTx(() =>
+      redeemPositions({
         conditionId: condition.id,
-      },
-    });
+      })
+    );
   };
 
   const hasBetted =

--- a/context/TxContext.tsx
+++ b/context/TxContext.tsx
@@ -8,19 +8,15 @@ import { type WriteContractParameters } from '@wagmi/core';
 import { writeContract } from 'wagmi/actions';
 import { TransactionModal } from '@/app/components';
 import { config } from '@/providers/chain-config';
-import { Address } from 'viem';
 
 export interface TxContextProps {
-  submitTx: (args: WriteContractParameters) => Promise<Address | void>;
-  submitCustomTx: (args: {
-    writeTxFunction: any;
-    args: any;
-  }) => Promise<Address | void>;
+  submitTx: (args: WriteContractParameters) => Promise<void>;
+  submitCustomTx: (tx: Function) => Promise<void>;
 }
 
 export const TxContext = createContext<TxContextProps>({
-  submitTx: async (args: WriteContractParameters) => '0x' as Address | void,
-  submitCustomTx: async (args: any) => '0x' as Address | void,
+  submitTx: async () => {},
+  submitCustomTx: async () => {},
 });
 
 export const TxProvider = ({ children }: PropsWithChildren) => {
@@ -30,15 +26,12 @@ export const TxProvider = ({ children }: PropsWithChildren) => {
 
   const { openModal } = useModal();
 
-  const submitCustomTx = async ({
-    writeTxFunction,
-    args,
-  }: any): Promise<Address | void> => submitWriteTx(() => writeTxFunction(args));
-
-  const submitTx = async (args: WriteContractParameters): Promise<Address | void> =>
+  const submitCustomTx = async (writeTxFn: Function): Promise<void> =>
+    submitWriteTx(() => writeTxFn());
+  const submitTx = async (args: WriteContractParameters): Promise<void> =>
     submitWriteTx(() => writeContract(config, args));
 
-  const submitWriteTx = async (writeTxFn?: any): Promise<Address | void> => {
+  const submitWriteTx = async (writeTxFn: Function): Promise<void> => {
     setIsTxLoading(true);
     setIsError(false);
     setTxHash('');


### PR DESCRIPTION
**Description**
New PR this fixes the problems we were having when clicking "redeem" on "My bets list" and "Market" views.
The problem was the loading modal was not showing and the success modal was triggered on click.

Now it should show proper loading tx modal and then on success it shows the green tick.
One of the problems was that we were using TxProvider which adds a `TransactionModal` component to the tree and we added another ones on `CardBet` and `UserBets` components, so when triggering openModal, there were 2 modals opening. Also some conditions on the modal needed extra checks.

This PR fixes those issues by making TxProvider more flexible by having 2 functions:

- `submitTx` (which receives the args and calls a write contract function from `wagmi`)
- `submitCustomTx` (which receives a customFunction and args that are called instead of the `writeContract` function)

In the end both do write contract calls but one can receive the function already prepared, as is the case of redeemPositions

**Summary**
add submitCustomTx to TxContext
- able to receive custom write function as an argument
- update components to use new function
- remove extra TransactionModals from components that was causing bugs