### PR TITLE
Don't hardcode 24h finalization

### DIFF
--- a/app/filters.tsx
+++ b/app/filters.tsx
@@ -4,7 +4,7 @@ import {
   OrderDirection,
 } from '@/queries/omen';
 import { AI_AGENTS_ALLOWLIST } from '../constants';
-import { _24HoursInSeconds, nowTimestamp } from '@/utils/time';
+import { nowTimestamp } from '@/utils/time';
 import {WXDAI, SDAI} from '@/constants/index';
 
 export type OrderFilter = {
@@ -53,8 +53,6 @@ export type StateFilter = {
   when: FixedProductMarketMaker_Filter;
 };
 
-const oneDayAgoTimestamp = nowTimestamp - _24HoursInSeconds;
-
 export const stateFilters: StateFilter[] = [
   {
     name: 'Open',
@@ -76,7 +74,8 @@ export const stateFilters: StateFilter[] = [
     key: 'finalizing',
     when: {
       resolutionTimestamp: null,
-      currentAnswerTimestamp_gt: oneDayAgoTimestamp,
+      answerFinalizedTimestamp_gt: nowTimestamp,
+      answerFinalizedTimestamp_not: null,
       openingTimestamp_lt: nowTimestamp,
       isPendingArbitration: false,
       currentAnswer_not: null,

--- a/entities/markets/market.ts
+++ b/entities/markets/market.ts
@@ -2,7 +2,7 @@ import { FixedProductMarketMaker } from '@/queries/omen';
 import { fromHex } from 'viem';
 import { Outcome } from '@/entities';
 import { isPast } from 'date-fns';
-import { _24HoursInSeconds, nowTimestamp } from '@/utils/time';
+import { nowTimestamp } from '@/utils/time';
 
 const INVALID_ANSWER_HEX =
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
@@ -25,7 +25,7 @@ export class Market {
     this.closingDate = new Date(+fpmm.openingTimestamp * 1000);
     this.isAnswerFinal =
       !!fpmm.resolutionTimestamp ||
-      nowTimestamp - fpmm.currentAnswerTimestamp > _24HoursInSeconds;
+      fpmm.answerFinalizedTimestamp < nowTimestamp;
 
     this.currentAnswer = fpmm.question?.currentAnswer
       ? fpmm.question.currentAnswer === INVALID_ANSWER_HEX

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -149,6 +149,7 @@ const getMarketsQuery = (
     $currentAnswer: Bytes
     $currentAnswer_not: Bytes
     $answerFinalizedTimestamp_lt: Int
+    $answerFinalizedTimestamp_gt: Int
     $openingTimestamp_lte: Int
     $scaledLiquidityParameter_gt: Int
     $resolutionTimestamp: Int
@@ -172,6 +173,7 @@ const getMarketsQuery = (
         ${params.currentAnswer !== undefined ? 'currentAnswer: $currentAnswer' : ''}
         ${params.currentAnswer_not !== undefined ? 'currentAnswer_not: $currentAnswer_not' : ''}
         ${params.answerFinalizedTimestamp_lt ? 'answerFinalizedTimestamp_lt: $answerFinalizedTimestamp_lt' : ''}
+        ${params.answerFinalizedTimestamp_gt ? 'answerFinalizedTimestamp_gt: $answerFinalizedTimestamp_gt' : ''}
         ${params.openingTimestamp_lte ? 'openingTimestamp_lte: $openingTimestamp_lte' : ''}
         ${params.scaledLiquidityParameter_gt !== undefined ? 'scaledLiquidityParameter_gt: $scaledLiquidityParameter_gt' : ''}
         ${params.resolutionTimestamp !== undefined ? 'resolutionTimestamp: $resolutionTimestamp' : ''}

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,2 +1,1 @@
-export const _24HoursInSeconds = 24 * 60 * 60;
 export const nowTimestamp = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
Yesterday, I created this market for some debugging: https://presagio.pages.dev/markets?id=0x0129d8d46e5869D10956BECf8E4A793309B04909

It's special because finalization period was only 1 hour.

On Presagio, it's still shown in Finalizing filter:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/371b1217-4442-4a8a-8863-4452b357d862)

And in the detail it also says I can still challenge it:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/779ab1f5-a48a-4aed-b711-cddf195cf75d)

This is because there is hard-coded 24h finalization period in the code, this PR is fixing that.  🙏 

On localhost in this branch:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/1e07c62c-5f83-4783-bcde-1cd3e2e31f45)

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/dbec1d9c-bea4-4ee8-9e2a-c7ff33b4bee8)

(this is bugged on this special market only atm, but we are going to change finalization period from 1 day to 3 days and then it would be bugged everywhere: https://github.com/gnosis/prediction-market-agent-tooling/pull/466)
