### PR TITLE
filter "test" market category when no category is passed

### DIFF
--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -179,6 +179,7 @@ const getMarketsQuery = (
         ${params.resolutionTimestamp !== undefined ? 'resolutionTimestamp: $resolutionTimestamp' : ''}
         ${params.currentAnswerTimestamp_gt !== undefined ? 'currentAnswerTimestamp_gt: $currentAnswerTimestamp_gt' : ''}
         ${params.collateralToken_in !== undefined ? 'collateralToken_in: $collateralToken_in' : ''}
+        ${!params.category_contains ? 'category_not_contains: "test"' : ''}
       }
     ) {
       ...marketData


### PR DESCRIPTION
This will enable the agents to create a test category meant for testing markets that will not appear on all markets but can still be filtered.