### PR TITLE
Show market not found if search params address is corrupt or not passed

### DIFF
--- a/app/(main)/markets/MarketDetails.tsx
+++ b/app/(main)/markets/MarketDetails.tsx
@@ -24,6 +24,7 @@ import { FA_EVENTS } from '@/analytics';
 import { ModalId, useModal } from '@/context';
 import { EmbedMarketModal } from '@/app/components/EmbedMarketModal';
 import { formatValueWithFixedDecimals } from '@/utils';
+import { MarketNotFound } from './MarketNotFound';
 
 interface MarketDetailsProps {
   id: Address;
@@ -205,8 +206,6 @@ const LoadingMarketDetails = () => (
     </div>
   </div>
 );
-
-const MarketNotFound = () => <div className="h-44">Market not found</div>;
 
 const BackButton = () => {
   const { back, push } = useRouter();

--- a/app/(main)/markets/MarketNotFound.tsx
+++ b/app/(main)/markets/MarketNotFound.tsx
@@ -1,0 +1,1 @@
+export const MarketNotFound = () => <div className="h-44">Market not found</div>;

--- a/app/(main)/markets/page.tsx
+++ b/app/(main)/markets/page.tsx
@@ -4,14 +4,19 @@ import { isAddress } from 'viem';
 import { MarketDetails } from './MarketDetails';
 import { useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
+import { MarketNotFound } from './MarketNotFound';
 
 const Market = () => {
   const searchParams = useSearchParams();
 
   const id = searchParams.get('id')?.toLocaleLowerCase();
 
-  // Empty State
-  if (!id || !isAddress(id)) return null;
+  if (!id || !isAddress(id))
+    return (
+      <main className="mt-12 flex w-full flex-col items-center px-6">
+        <MarketNotFound />;
+      </main>
+    );
 
   return (
     <main className="mt-12 flex w-full flex-col items-center px-6">


### PR DESCRIPTION

Currently we are returning null if search params address is null or corrupt. Which just displays an empty interface.

<img width="1464" alt="image" src="https://github.com/user-attachments/assets/262f1117-fbea-4b41-a3b8-bfcebfd11b6f">

Showing market not found is a better experience.

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/25694507-f908-4c86-8d2e-0a47966a3143">
