### PR TITLE
[FEAT][PGIO-132] - Hide Jobs markets from All category

### DIFF
--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -184,7 +184,7 @@ const getMarketsQuery = (
         ${params.resolutionTimestamp !== undefined ? 'resolutionTimestamp: $resolutionTimestamp' : ''}
         ${params.currentAnswerTimestamp_gt !== undefined ? 'currentAnswerTimestamp_gt: $currentAnswerTimestamp_gt' : ''}
         ${params.collateralToken_in !== undefined ? 'collateralToken_in: $collateralToken_in' : ''}
-        ${!params.category_contains ? 'category_not_contains: "test"' : ''}
+        ${!params.category_contains ? 'category_not_in: ["test", "jobs"]' : ''}
       }
     ) {
       ...marketData


### PR DESCRIPTION
 ## Fixes: [PGIO-132](https://linear.app/swaprhq/issue/PGIO-132/hide-jobs-markets-from-all-category)

## Description
* Adds "Jobs" category to the filter list to hide markets when displaying the All category.

## Visual Evidence
https://www.loom.com/share/280026a67ae34b13b7e5087986bcf9f9?sid=9638d240-8a62-4f20-88e0-7593b7c954b7