### PR TITLE
feat(PGIO-131): add ranking algorithm to landing page

### DIFF
--- a/app/(main)/filters.ts
+++ b/app/(main)/filters.ts
@@ -16,27 +16,39 @@ export type OrderFilter = {
 
 export const orderFilters: OrderFilter[] = [
   {
-    name: 'New',
-    key: 'new',
-    orderBy: FixedProductMarketMaker_OrderBy.CreationTimestamp,
-    orderDirection: OrderDirection.Desc,
-  },
-  {
     name: 'Most active',
     key: 'active',
     orderBy: FixedProductMarketMaker_OrderBy.UsdRunningDailyVolume,
     orderDirection: OrderDirection.Desc,
   },
   {
+    name: 'New',
+    key: 'new',
+    orderBy: FixedProductMarketMaker_OrderBy.CreationTimestamp,
+    orderDirection: OrderDirection.Desc,
+  },
+  {
     name: 'High volume',
-    key: 'high',
+    key: 'high-volume',
     orderBy: FixedProductMarketMaker_OrderBy.UsdVolume,
     orderDirection: OrderDirection.Desc,
   },
   {
     name: 'Low volume',
-    key: 'low',
+    key: 'low-volume',
     orderBy: FixedProductMarketMaker_OrderBy.UsdVolume,
+    orderDirection: OrderDirection.Asc,
+  },
+  {
+    name: 'High liquidity',
+    key: 'high-liquidity',
+    orderBy: FixedProductMarketMaker_OrderBy.ScaledCollateralVolume,
+    orderDirection: OrderDirection.Desc,
+  },
+  {
+    name: 'Low liquidity',
+    key: 'low-liquidity',
+    orderBy: FixedProductMarketMaker_OrderBy.ScaledCollateralVolume,
     orderDirection: OrderDirection.Asc,
   },
   {

--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -1,6 +1,7 @@
 import { gql, request } from 'graphql-request';
 import {
   FixedProductMarketMaker_Filter,
+  FixedProductMarketMaker_OrderBy,
   FpmmTrade_Filter,
   FpmmTransaction_Filter,
   Query,
@@ -126,8 +127,9 @@ const marketDataFragment = gql`
     }
     outcomes
     outcomeTokenMarginalPrices
-    usdVolume
     resolutionTimestamp
+    usdRunningDailyVolume
+    usdVolume
     currentAnswer
     currentAnswerTimestamp
     fee
@@ -406,6 +408,12 @@ const getMarket = async (params: QueryFixedProductMarketMakerArgs) => {
   return !hasDangerousKeywords ? response : null;
 };
 
+type PrimaryOrderBy =
+  | FixedProductMarketMaker_OrderBy.UsdRunningDailyVolume
+  | FixedProductMarketMaker_OrderBy.CreationTimestamp
+  | FixedProductMarketMaker_OrderBy.UsdVolume
+  | FixedProductMarketMaker_OrderBy.ScaledCollateralVolume
+  | FixedProductMarketMaker_OrderBy.OpeningTimestamp;
 const getMarkets = async (
   params: QueryFixedProductMarketMakersArgs & FixedProductMarketMaker_Filter
 ) => {
@@ -419,7 +427,22 @@ const getMarkets = async (
     fpmm => !marketHasDangerousKeyword(fpmm)
   );
 
-  return { fixedProductMarketMakers: filteredResults };
+  const sortedResults = filteredResults.sort((a, b) => {
+    if (b[params.orderBy as PrimaryOrderBy] !== a[params.orderBy as PrimaryOrderBy]) {
+      return (
+        Number(b[params.orderBy as PrimaryOrderBy]) -
+        Number(a[params.orderBy as PrimaryOrderBy])
+      );
+    }
+
+    if (params.orderBy === FixedProductMarketMaker_OrderBy.UsdRunningDailyVolume) {
+      return Number(b.usdVolume) - Number(a.usdVolume);
+    }
+
+    return Number(b.usdRunningDailyVolume) - Number(a.usdRunningDailyVolume);
+  });
+
+  return { fixedProductMarketMakers: sortedResults };
 };
 
 const getAccountMarkets = async (


### PR DESCRIPTION
 ## Fixes: [PGIO-131](https://linear.app/swaprhq/issue/PGIO-131/add-ranking-algorithm-to-landing-page)

## Description
* Adds liquidity filters
* Sets "Most Active" as the default filter
* Adds secondary sorting logic