### PR TITLE
fix: market tabs overflowing on mobile

### DIFF
--- a/app/(main)/markets/MarketDetails.tsx
+++ b/app/(main)/markets/MarketDetails.tsx
@@ -175,7 +175,7 @@ export const MarketDetails = ({ id }: MarketDetailsProps) => {
               <ToggleGroup
                 value={tab}
                 onChange={setTab}
-                className="w-full justify-around md:w-full"
+                className="w-full justify-around overflow-auto md:w-full"
               >
                 {Object.values(Tabs).map(tab => (
                   <div className="w-full" key={tab}>


### PR DESCRIPTION
fixes this:
<img width="384" alt="image" src="https://github.com/user-attachments/assets/7cd20e64-37cf-4f4f-9d86-92fc88557b15" />
