### PR TITLE
Use the MarketsHighlight component to highlight 3 markets and make landing more interesting

### DIFF
--- a/analytics/index.ts
+++ b/analytics/index.ts
@@ -41,6 +41,7 @@ export const FA_EVENTS = {
     },
   },
   MARKETS: {
+    CAROUSEL: 'click/markets/carousel',
     CATEGORY: (category: string) => `click/markets/category-${category}`,
     DETAILS: {
       EMBED: {

--- a/app/(main)/MarketsHighlight.tsx
+++ b/app/(main)/MarketsHighlight.tsx
@@ -17,7 +17,7 @@ import { FA_EVENTS } from '@/analytics';
 import { trackEvent } from 'fathom-client';
 
 interface MarketsHighlightProps {
-  markets: any[];
+  markets: FixedProductMarketMaker[];
 }
 
 export const MarketsHighlight = ({ markets }: MarketsHighlightProps) => {

--- a/app/(main)/MarketsHighlight.tsx
+++ b/app/(main)/MarketsHighlight.tsx
@@ -35,12 +35,12 @@ export const MarketsHighlight = ({ markets }: MarketsHighlightProps) => {
       opts={{ loop: true }}
       className="group relative mb-6 w-full"
     >
-      <CarouselSelector className="absolute bottom-0 left-0 right-0 z-50 mx-auto mb-6" />
-      <div className="absolute bottom-0 right-0 z-50 mb-4 mr-6 flex space-x-2 opacity-0 transition duration-300 ease-in-out group-hover:opacity-100">
+      <CarouselSelector className="absolute bottom-3 left-0 right-0 z-50 mx-auto mb-6 md:bottom-0" />
+      <div className="absolute bottom-2 right-0 z-50 mb-4 mr-6 flex space-x-2 opacity-0 transition duration-300 ease-in-out group-hover:opacity-100">
         <CarouselPrevious />
         <CarouselNext />
       </div>
-      <CarouselContent className="pb-2">
+      <CarouselContent className="relative pb-2">
         {randomMarkets.map(market => (
           <HighlightCarouselItem key={market.id} market={market} />
         ))}
@@ -56,7 +56,7 @@ const HighlightCarouselItem = ({ market }: { market: FixedProductMarketMaker }) 
     <CarouselItem key={market.id}>
       <Link
         href={`/markets?id=${market.id}`}
-        className="flex h-auto min-h-[400px] w-full flex-col-reverse justify-between rounded-20 bg-surface-primary-main bg-gradient-to-b from-surface-surface-0 to-surface-surface-1 shadow-2 ring-1 ring-outline-base-em md:h-72 md:min-h-fit md:flex-row 2xl:h-96"
+        className="flex min-h-[600px] w-auto flex-col-reverse justify-between rounded-20 bg-surface-primary-main bg-gradient-to-b from-surface-surface-0 to-surface-surface-1 shadow-2 ring-1 ring-outline-base-em md:h-72 md:min-h-fit md:flex-row 2xl:h-96"
       >
         <div className="m-0 flex w-full max-w-2xl flex-col space-y-8 p-4 md:mx-6 md:my-8 md:mr-10 md:p-0 lg:mx-8 lg:mr-28">
           <div className="flex flex-col space-y-4">
@@ -77,7 +77,7 @@ const HighlightCarouselItem = ({ market }: { market: FixedProductMarketMaker }) 
           priority
           width={200}
           height={200}
-          className="h-44 w-full rounded-e-0 rounded-t-20 md:h-full md:w-1/2 md:rounded-e-20 md:rounded-s-0 2xl:w-2/5"
+          className="h-full w-full rounded-e-0 rounded-t-20 bg-outline-primary-low-em md:w-1/2 md:rounded-e-20 md:rounded-s-0 2xl:w-2/5"
           marketId={market.id}
           style={{ objectFit: 'cover', objectPosition: 'top' }}
           alt="Market highlight"

--- a/app/(main)/MarketsHighlight.tsx
+++ b/app/(main)/MarketsHighlight.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import {
-  FixedProductMarketMaker,
-  FixedProductMarketMaker_OrderBy,
-  getMarket,
-} from '@/queries/omen';
+import { FixedProductMarketMaker } from '@/queries/omen';
 import { MarketThumbnail, OutcomeBar, TokenLogo } from '@/app/components';
 import { formatEtherWithFixedDecimals, remainingTime } from '@/utils';
 import {
@@ -17,6 +13,8 @@ import {
   CarouselSelector,
 } from '../components/Carousel';
 import Autoplay from 'embla-carousel-autoplay';
+import { FA_EVENTS } from '@/analytics';
+import { trackEvent } from 'fathom-client';
 
 interface MarketsHighlightProps {
   markets: any[];
@@ -55,6 +53,7 @@ const HighlightCarouselItem = ({ market }: { market: FixedProductMarketMaker }) 
   return (
     <CarouselItem key={market.id}>
       <Link
+        onClick={() => trackEvent(FA_EVENTS.MARKETS.CAROUSEL)}
         href={`/markets?id=${market.id}`}
         className="flex min-h-[600px] w-auto flex-col-reverse justify-between rounded-20 bg-surface-primary-main bg-gradient-to-b from-surface-surface-0 to-surface-surface-1 shadow-2 ring-1 ring-outline-base-em md:h-72 md:min-h-fit md:flex-row 2xl:h-96"
       >

--- a/app/(main)/MarketsHighlight.tsx
+++ b/app/(main)/MarketsHighlight.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { useQueries } from '@tanstack/react-query';
 import Link from 'next/link';
-import { FixedProductMarketMaker, getMarket } from '@/queries/omen';
-import { OutcomeBar, TokenLogo } from '@/app/components';
+import {
+  FixedProductMarketMaker,
+  FixedProductMarketMaker_OrderBy,
+  getMarket,
+} from '@/queries/omen';
+import { MarketThumbnail, OutcomeBar, TokenLogo } from '@/app/components';
 import { formatEtherWithFixedDecimals, remainingTime } from '@/utils';
 import {
   Carousel,
@@ -14,28 +17,13 @@ import {
   CarouselSelector,
 } from '../components/Carousel';
 import Autoplay from 'embla-carousel-autoplay';
-import { highlightedMarketsList } from '@/market-highlight.config';
-import defaultHighlightImage from '@/public/assets/highlights/default.png';
-import Image from 'next/image';
-import { useState } from 'react';
 
-export const MarketsHighlight = () => {
-  const { data: markets, isLoading } = useQueries({
-    queries: Object.keys(highlightedMarketsList).map(id => ({
-      queryKey: ['getMarket', id],
-      queryFn: async () => getMarket({ id }),
-    })),
-    combine: results => {
-      return {
-        data: results
-          .map(result => result.data?.fixedProductMarketMaker)
-          .filter((market): market is FixedProductMarketMaker => !!market),
-        isLoading: results.some(result => result.isPending),
-      };
-    },
-  });
+interface MarketsHighlightProps {
+  markets: any[];
+}
 
-  if (markets.length === 0 || isLoading) return null;
+export const MarketsHighlight = ({ markets }: MarketsHighlightProps) => {
+  const randomMarkets = markets.sort(() => 0.5 - Math.random()).slice(0, 3);
 
   return (
     <Carousel
@@ -53,7 +41,7 @@ export const MarketsHighlight = () => {
         <CarouselNext />
       </div>
       <CarouselContent className="pb-2">
-        {markets.map(market => (
+        {randomMarkets.map(market => (
           <HighlightCarouselItem key={market.id} market={market} />
         ))}
       </CarouselContent>
@@ -62,7 +50,6 @@ export const MarketsHighlight = () => {
 };
 
 const HighlightCarouselItem = ({ market }: { market: FixedProductMarketMaker }) => {
-  const [image, setImage] = useState(highlightedMarketsList[market.id].image);
   const closingDate = new Date(+market.openingTimestamp * 1000);
 
   return (
@@ -86,13 +73,14 @@ const HighlightCarouselItem = ({ market }: { market: FixedProductMarketMaker }) 
             </p>
           </div>
         </div>
-        <Image
-          className="h-44 w-full rounded-e-0 rounded-t-20 md:h-full md:w-1/2 md:rounded-e-20 md:rounded-s-0 2xl:w-2/5"
-          src={image}
+        <MarketThumbnail
           priority
-          alt="Market highlight"
+          width={200}
+          height={200}
+          className="h-44 w-full rounded-e-0 rounded-t-20 md:h-full md:w-1/2 md:rounded-e-20 md:rounded-s-0 2xl:w-2/5"
+          marketId={market.id}
           style={{ objectFit: 'cover', objectPosition: 'top' }}
-          onError={() => setImage(defaultHighlightImage)}
+          alt="Market highlight"
         />
       </Link>
     </CarouselItem>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -276,7 +276,7 @@ export default function HomePage() {
 
   return (
     <div className="mt-12 justify-center space-y-8 px-6 md:flex md:flex-col md:items-center md:px-10 lg:px-20 xl:px-40">
-      <MarketsHighlight />
+      <MarketsHighlight markets={markets ?? []} />
       {openMarketsLoading ? (
         <LoadingMarketCategories />
       ) : (

--- a/app/components/MarketThumbnail.tsx
+++ b/app/components/MarketThumbnail.tsx
@@ -8,6 +8,7 @@ import request from 'graphql-request';
 
 interface MarketThumbnailProps extends Omit<ImageProps, 'src' | 'alt'> {
   marketId: string;
+  alt?: string;
 }
 
 type OmenThumbnailMapping = { omenThumbnailMapping: { image_hash: string } };
@@ -37,6 +38,6 @@ export const MarketThumbnail = ({ marketId, ...props }: MarketThumbnailProps) =>
 
   if (!ipfsHash) return null;
   return (
-    <Image {...props} src={`https://ipfs.io/ipfs/${ipfsHash}`} alt="Thumbnail image" />
+    <Image src={`https://ipfs.io/ipfs/${ipfsHash}`} alt="Thumbnail image" {...props} />
   );
 };


### PR DESCRIPTION
Since we already have some ranking and the first 12 markets should be the best in terms of liquidity and betting activity, we can randomly highlight the markets, since it makes the page more interesting.

**preview**

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/5bb5c5dc-6075-42f8-a30c-503591589b8f" />
