### PR TITLE
fix: closing soon wrong order

### DIFF
--- a/queries/omen/markets.ts
+++ b/queries/omen/markets.ts
@@ -419,21 +419,24 @@ const getMarkets = async (
    *
    * This fn applies a secondary sort criteria if we get a primary sort result that
    * has multiple markets with the same sorted value.
-   * This fn only sorts a given page results.
+   * This sort will only work for UsdRunningDailyVolume ordering.
    */
-  const sortedResults = response.fixedProductMarketMakers?.sort((a, b) => {
-    const orderBy = params.orderBy as PrimaryOrderBy;
+  const sortedResults =
+    params.orderBy === FixedProductMarketMaker_OrderBy.UsdRunningDailyVolume
+      ? response.fixedProductMarketMakers?.sort((a, b) => {
+          const orderBy = params.orderBy as PrimaryOrderBy;
 
-    if (b[orderBy] !== a[orderBy]) {
-      return Number(b[orderBy]) - Number(a[orderBy]);
-    }
+          if (b[orderBy] !== a[orderBy]) {
+            return Number(b[orderBy]) - Number(a[orderBy]);
+          }
 
-    if (orderBy === FixedProductMarketMaker_OrderBy.UsdRunningDailyVolume) {
-      return Number(b.usdVolume) - Number(a.usdVolume);
-    }
+          if (orderBy === FixedProductMarketMaker_OrderBy.UsdRunningDailyVolume) {
+            return Number(b.usdVolume) - Number(a.usdVolume);
+          }
 
-    return Number(b.usdRunningDailyVolume) - Number(a.usdRunningDailyVolume);
-  });
+          return Number(b.usdRunningDailyVolume) - Number(a.usdRunningDailyVolume);
+        })
+      : response.fixedProductMarketMakers;
 
   return { fixedProductMarketMakers: sortedResults };
 };


### PR DESCRIPTION
- Only do a special sorting for the landing page markets AKA UsdRunningDailyVolume

![image](https://github.com/user-attachments/assets/3a7e4895-b399-44ab-bb6f-9cf5d2b4efa3)
